### PR TITLE
move MPFR target link before GMP resolves mingw64 linker issue undefined...

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,12 +29,14 @@ set_target_properties( SFCGAL PROPERTIES VERSION ${SFCGAL_VERSION}
                                          SOVERSION ${SFCGAL_VERSION_MAJOR} )
 
 target_link_libraries( SFCGAL ${CGAL_LIBRARIES} )
-if( ${SFCGAL_WITH_GMP} )
-	target_link_libraries( SFCGAL ${GMP_LIBRARIES} )
-endif( ${SFCGAL_WITH_GMP} )
 if( ${SFCGAL_WITH_MPFR} )
 	target_link_libraries( SFCGAL ${MPFR_LIBRARIES} )
 endif( ${SFCGAL_WITH_MPFR} )
+
+if( ${SFCGAL_WITH_GMP} )
+	target_link_libraries( SFCGAL ${GMP_LIBRARIES} )
+endif( ${SFCGAL_WITH_GMP} )
+
 if( ${SFCGAL_WITH_OSG} )
 	 target_link_libraries( SFCGAL ${OPENSCENEGRAPH_LIBRARIES} )
 endif()


### PR DESCRIPTION
... reference to `__gmp_get_memory_functions`. Issue is described in http://www.mpfr.org/faq.html#undef_ref2 with some platforms and suggested it should always be first -  https://github.com/Oslandia/SFCGAL/issues/59
