### PR TITLE
Added sfcgal_geometry_as_text_decim function to C API

### DIFF
--- a/src/capi/sfcgal_c.cpp
+++ b/src/capi/sfcgal_c.cpp
@@ -184,6 +184,16 @@ extern "C" void sfcgal_geometry_as_text( const sfcgal_geometry_t* pgeom, char** 
     )
 }
 
+extern "C" void sfcgal_geometry_as_text_decim( const sfcgal_geometry_t* pgeom, int numDecimals, char** buffer, size_t* len )
+{
+    SFCGAL_GEOMETRY_CONVERT_CATCH_TO_ERROR_NO_RET(
+        std::string wkt = reinterpret_cast<const SFCGAL::Geometry*>( pgeom )->asText( numDecimals );
+        *buffer = ( char* )__sfcgal_alloc_handler( wkt.size() + 1 );
+        *len = wkt.size();
+        strncpy( *buffer, wkt.c_str(), *len );
+    )
+}
+
 /**
  * Point
  */
@@ -561,10 +571,10 @@ extern "C" void sfcgal_prepared_geometry_set_srid( sfcgal_prepared_geometry_t* p
     )
 }
 
-extern "C" void sfcgal_prepared_geometry_as_ewkt( const sfcgal_prepared_geometry_t* pgeom, int /*num_decimals*/, char** buffer, size_t* len )
+extern "C" void sfcgal_prepared_geometry_as_ewkt( const sfcgal_prepared_geometry_t* pgeom, int num_decimals, char** buffer, size_t* len )
 {
     SFCGAL_GEOMETRY_CONVERT_CATCH_TO_ERROR_NO_RET(
-        std::string ewkt = reinterpret_cast<const SFCGAL::PreparedGeometry*>( pgeom )->asEWKT();
+        std::string ewkt = reinterpret_cast<const SFCGAL::PreparedGeometry*>( pgeom )->asEWKT( num_decimals );
         *buffer = ( char* )__sfcgal_alloc_handler( ewkt.size() + 1 );
         *len = ewkt.size();
         strncpy( *buffer, ewkt.c_str(), *len );

--- a/src/capi/sfcgal_c.h
+++ b/src/capi/sfcgal_c.h
@@ -111,11 +111,20 @@ SFCGAL_API sfcgal_geometry_t*        sfcgal_geometry_clone( const sfcgal_geometr
 SFCGAL_API void                      sfcgal_geometry_delete( sfcgal_geometry_t* );
 
 /**
- * Returns a WKT representation of the given geometry
+ * Returns a WKT representation of the given geometry using CGAL exact integer fractions as coordinate values
  * @post buffer is returned allocated and must be freed by the caller
  * @ingroup capi
  */
 SFCGAL_API void                      sfcgal_geometry_as_text( const sfcgal_geometry_t*, char** buffer, size_t* len );
+
+/**
+ * Returns a WKT representation of the given geometry using floating point coordinate values.
+ * Floating point precision can be set via the numDecimals parameter.
+ * Setting numDecimals to -1 yields the same result as sfcgal_geometry_as_text. 
+ * @post buffer is returned allocated and must be freed by the caller
+ * @ingroup capi
+ */
+SFCGAL_API void                      sfcgal_geometry_as_text_decim( const sfcgal_geometry_t*, int numDecimals, char** buffer, size_t* len );
 
 /**
  * Creates an empty point


### PR DESCRIPTION
new **sfcgal_geometry_as_text_decim** function allows to set the numDecimals parameter which is passed to the asText function and then used in WktWriter. This way the precision of coordinate values in the generated WKT can be controlled over the C API. Most importantly, the default "exact mode" of CGAL outputting integer fractions (= invalid WKT) can be avoided.

The existing function was not touched to ensure backwards compatibility.

removed comments for num_decimals parameter in **sfcgal_prepared_geometry_as_ewkt** function. so far, passed num_decimals did not have any effect since they were not passed to the asEWKT method. this is changed now and the precision can be controlled for EWKT as well.

The first enhancement was previously discussed and agreed upon in [Issue #70](https://github.com/Oslandia/SFCGAL/issues/70).
Should the second EWKT-related enhancement be undesired by the original authors, please reject that part or suggest a different implementation.

Many thanks,
Matthias