### PR TITLE
Fix spelling errors accourding to lintian tool of the debian distribution

### DIFF
--- a/src/Exception.h
+++ b/src/Exception.h
@@ -48,7 +48,7 @@ public:
      */
     virtual const char* what() const throw();
     /**
-     * returns diagnostic informations (file, line, etc.)
+     * returns diagnostic information (file, line, etc.)
      */
     std::string diagnostic() const throw();
 protected:

--- a/src/algorithm/connection.cpp
+++ b/src/algorithm/connection.cpp
@@ -51,7 +51,7 @@ void SurfaceGraph::addRing( const LineString& ring, FaceIndex faceIndex )
 
             if ( foundEdgeWithBadOrientation != _edgeMap.end() ) {
                 _isValid = Validity::invalid(
-                               ( boost::format( "inconsistant orientation of PolyhedralSurface detected at edge %d (%d-%d) of polygon %d" ) % s % edge.first % edge.second % faceIndex ).str()
+                               ( boost::format( "inconsistent orientation of PolyhedralSurface detected at edge %d (%d-%d) of polygon %d" ) % s % edge.first % edge.second % faceIndex ).str()
                            );
             }
 

--- a/src/detail/graph/Edge.h
+++ b/src/detail/graph/Edge.h
@@ -28,7 +28,7 @@ namespace graph {
 
 /**
  * @brief [private]An edge in a GeometryGraph with minimal requirements (some algorithms could need
- * more informations)
+ * more information)
  */
 struct SFCGAL_API Edge {
     Edge( const int& face_ = -1 );

--- a/src/detail/graph/GeometryGraph.h
+++ b/src/detail/graph/GeometryGraph.h
@@ -52,7 +52,7 @@ inline EdgeDirection reverse( const EdgeDirection& direction )
  *
  * @brief [private]Represents the vertices and edges for a list of geometries.
  *
- * A boost::adjancency_list is wrapped in order to be able to annex some informations
+ * A boost::adjancency_list is wrapped in order to be able to annex some information
  * and to provide basic functionalities.
  *
  * @warning duplicate matching is performed in GeometryGraphBuilder (allows to modify position once it's done)

--- a/viewer/src/SFCGAL/viewer/plugins/DataPlugin.cpp
+++ b/viewer/src/SFCGAL/viewer/plugins/DataPlugin.cpp
@@ -91,7 +91,7 @@ void DataPlugin::load()
 {
     QMenu* pluginMenu = viewerWindow()->menuBar()->addMenu( "Data" ) ;
 
-    QAction* actionDisplayInformations = pluginMenu->addAction( QString( "&display informations" ) );
+    QAction* actionDisplayInformations = pluginMenu->addAction( QString( "&display information" ) );
     connect( actionDisplayInformations, SIGNAL( triggered() ), this, SLOT( displayInformations() ) );
 }
 


### PR DESCRIPTION
Hello,

I'm about to create a debian/ubuntu package of the library. Unfortunately the lintian tool is very pedantic in reporting errors. For this reason here is a patch to fix a couple of spelling errors.

Having to maintain them as a separate patch is somewhat ugly thus it would be nice if you could pull this into upstream and (which would be even better) tagging a version v1.1.1 including the changes.

Regards

Sven