### PR TITLE
Approximate medial axis

### DIFF
--- a/src/algorithm/straightSkeleton.cpp
+++ b/src/algorithm/straightSkeleton.cpp
@@ -102,33 +102,33 @@ straightSkeleton(const Polygon_with_holes_2& poly)
 ///
 ///
 ///
-std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation, NoValidityCheck )
+std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation, NoValidityCheck, bool innerOnly )
 {
     switch ( g.geometryTypeId() ) {
     case TYPE_TRIANGLE:
-        return straightSkeleton( g.as< Triangle >().toPolygon(), autoOrientation ) ;
+        return straightSkeleton( g.as< Triangle >().toPolygon(), autoOrientation, innerOnly ) ;
 
     case TYPE_POLYGON:
-        return straightSkeleton( g.as< Polygon >(), autoOrientation ) ;
+        return straightSkeleton( g.as< Polygon >(), autoOrientation, innerOnly ) ;
 
     case TYPE_MULTIPOLYGON:
-        return straightSkeleton( g.as< MultiPolygon >(), autoOrientation ) ;
+        return straightSkeleton( g.as< MultiPolygon >(), autoOrientation, innerOnly ) ;
 
     default:
         return std::auto_ptr< MultiLineString >( new MultiLineString );
     }
 }
 
-std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation )
+std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation, bool innerOnly )
 {
     SFCGAL_ASSERT_GEOMETRY_VALIDITY_2D( g );
 
-    return straightSkeleton( g, autoOrientation, NoValidityCheck() );
+    return straightSkeleton( g, autoOrientation, NoValidityCheck(), innerOnly );
 }
 ///
 ///
 ///
-std::auto_ptr< MultiLineString > straightSkeleton( const Polygon& g, bool /*autoOrientation*/ )
+std::auto_ptr< MultiLineString > straightSkeleton( const Polygon& g, bool /*autoOrientation*/, bool innerOnly )
 {
     std::auto_ptr< MultiLineString > result( new MultiLineString );
 
@@ -162,7 +162,7 @@ std::auto_ptr< MultiLineString > straightSkeleton( const Polygon& g, bool /*auto
         BOOST_THROW_EXCEPTION( Exception( "CGAL failed to create straightSkeleton" ) ) ;
     }
 
-    straightSkeletonToMultiLineString( *skeleton, *result ) ;
+    straightSkeletonToMultiLineString( *skeleton, *result, innerOnly ) ;
     return result ;
 }
 
@@ -170,7 +170,7 @@ std::auto_ptr< MultiLineString > straightSkeleton( const Polygon& g, bool /*auto
 ///
 ///
 ///
-std::auto_ptr< MultiLineString > straightSkeleton( const MultiPolygon& g, bool /*autoOrientation*/ )
+std::auto_ptr< MultiLineString > straightSkeleton( const MultiPolygon& g, bool /*autoOrientation*/, bool innerOnly )
 {
     std::auto_ptr< MultiLineString > result( new MultiLineString );
 
@@ -182,7 +182,7 @@ std::auto_ptr< MultiLineString > straightSkeleton( const MultiPolygon& g, bool /
             BOOST_THROW_EXCEPTION( Exception( "CGAL failed to create straightSkeleton" ) ) ;
         }
 
-        straightSkeletonToMultiLineString( *skeleton, *result ) ;
+        straightSkeletonToMultiLineString( *skeleton, *result, innerOnly ) ;
     }
 
     return result ;
@@ -193,7 +193,7 @@ std::auto_ptr< MultiLineString > approximateMedialAxis( const Geometry& g )
     SFCGAL_ASSERT_GEOMETRY_VALIDITY_2D( g );
 
     std::auto_ptr< MultiLineString > ms =
-        straightSkeleton( g, false, NoValidityCheck() );
+        straightSkeleton( g, false, NoValidityCheck(), true );
 
     /* Remove from output set lines that touch the border */
 }

--- a/src/algorithm/straightSkeleton.cpp
+++ b/src/algorithm/straightSkeleton.cpp
@@ -192,10 +192,10 @@ std::auto_ptr< MultiLineString > approximateMedialAxis( const Geometry& g )
 {
     SFCGAL_ASSERT_GEOMETRY_VALIDITY_2D( g );
 
-    std::auto_ptr< MultiLineString > ms =
+    std::auto_ptr< MultiLineString > mx =
         straightSkeleton( g, false, NoValidityCheck(), true );
 
-    /* Remove from output set lines that touch the border */
+    return mx;
 }
 
 }//namespace algorithm

--- a/src/algorithm/straightSkeleton.cpp
+++ b/src/algorithm/straightSkeleton.cpp
@@ -47,7 +47,8 @@ typedef CGAL::Straight_skeleton_2<Kernel>  Straight_skeleton_2 ;
 template<class K>
 void straightSkeletonToMultiLineString(
     const CGAL::Straight_skeleton_2<K>& ss,
-    MultiLineString& result
+    MultiLineString& result,
+    bool innerOnly=false
 )
 {
     typedef CGAL::Straight_skeleton_2<K> Ss ;
@@ -62,6 +63,11 @@ void straightSkeletonToMultiLineString(
     for ( Halfedge_const_iterator it = ss.halfedges_begin(); it != ss.halfedges_end(); ++it ) {
         // skip contour edge
         if ( ! it->is_bisector() ) {
+            continue ;
+        }
+
+        // Skip non-inner edges if requested
+        if ( innerOnly && ! it->is_inner_bisector() ) {
             continue ;
         }
 
@@ -182,6 +188,15 @@ std::auto_ptr< MultiLineString > straightSkeleton( const MultiPolygon& g, bool /
     return result ;
 }
 
+std::auto_ptr< MultiLineString > approximateMedialAxis( const Geometry& g )
+{
+    SFCGAL_ASSERT_GEOMETRY_VALIDITY_2D( g );
+
+    std::auto_ptr< MultiLineString > ms =
+        straightSkeleton( g, false, NoValidityCheck() );
+
+    /* Remove from output set lines that touch the border */
+}
 
 }//namespace algorithm
 }//namespace SFCGAL

--- a/src/algorithm/straightSkeleton.h
+++ b/src/algorithm/straightSkeleton.h
@@ -53,7 +53,7 @@ SFCGAL_API std::auto_ptr< MultiLineString > approximateMedialAxis( const Geometr
  * @ingroup public_api
  * @pre g is a valid geometry
  */
-SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation = true ) ;
+SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation = true, bool innerOnly = false ) ;
 
 /**
  * @brief build a 2D straight skeleton for a Polygon
@@ -63,18 +63,18 @@ SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g,
  * @pre g is a valid geometry
  * @warning No actual validity check is done
  */
-SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation, NoValidityCheck ) ;
+SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation, NoValidityCheck, bool innerOnly = false ) ;
 
 /**
  * @brief build a 2D straight skeleton for a Polygon
  * @ingroup detail
  */
-SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const Polygon& g, bool autoOrientation = true ) ;
+SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const Polygon& g, bool autoOrientation = true, bool innerOnly = false ) ;
 /**
  * @brief build a 2D straight skeleton for a Polygon
  * @ingroup detail
  */
-SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const MultiPolygon& g, bool autoOrientation = true ) ;
+SFCGAL_API std::auto_ptr< MultiLineString > straightSkeleton( const MultiPolygon& g, bool autoOrientation = true, bool innerOnly = false ) ;
 
 }//namespace algorithm
 }//namespace SFCGAL

--- a/src/algorithm/straightSkeleton.h
+++ b/src/algorithm/straightSkeleton.h
@@ -37,6 +37,14 @@ namespace algorithm {
 struct NoValidityCheck;
 
 /**
+ * @brief build an approximate medial axis for a Polygon
+ * @param g input geometry
+ * @ingroup public_api
+ * @pre g is a valid geometry
+ */
+SFCGAL_API std::auto_ptr< MultiLineString > approximateMedialAxis( const Geometry& g );
+
+/**
  * @brief build a 2D straight skeleton for a Polygon
  * @todo add supports for TriangulatedSurface and PolyhedralSurface
  * @todo output M as distance to border?

--- a/src/capi/sfcgal_c.cpp
+++ b/src/capi/sfcgal_c.cpp
@@ -731,6 +731,7 @@ SFCGAL_GEOMETRY_FUNCTION_BINARY_CONSTRUCTION( union_3d, SFCGAL::algorithm::union
 SFCGAL_GEOMETRY_FUNCTION_UNARY_CONSTRUCTION( convexhull, SFCGAL::algorithm::convexHull )
 SFCGAL_GEOMETRY_FUNCTION_UNARY_CONSTRUCTION( convexhull_3d, SFCGAL::algorithm::convexHull3D )
 SFCGAL_GEOMETRY_FUNCTION_UNARY_CONSTRUCTION( straight_skeleton, SFCGAL::algorithm::straightSkeleton )
+SFCGAL_GEOMETRY_FUNCTION_UNARY_CONSTRUCTION( approximate_medial_axis, SFCGAL::algorithm::approximateMedialAxis )
 SFCGAL_GEOMETRY_FUNCTION_UNARY_CONSTRUCTION( tesselate, SFCGAL::algorithm::tesselate )
 
 #define SFCGAL_GEOMETRY_FUNCTION_UNARY_MEASURE( name, sfcgal_function ) \

--- a/src/capi/sfcgal_c.h
+++ b/src/capi/sfcgal_c.h
@@ -782,6 +782,14 @@ SFCGAL_API sfcgal_geometry_t*          sfcgal_geometry_offset_polygon( const sfc
  */
 SFCGAL_API sfcgal_geometry_t*          sfcgal_geometry_straight_skeleton( const sfcgal_geometry_t* geom );
 
+/**
+ * Returns the approximate medial axis for the given Polygon
+ * Approximate medial axis is based on straight skeleton
+ * @pre isValid(geom) == true
+ * @ingroup capi
+ */
+SFCGAL_API sfcgal_geometry_t*          sfcgal_geometry_approximate_medial_axis( const sfcgal_geometry_t* geom );
+
 /*--------------------------------------------------------------------------------------*
  *
  * Error handling

--- a/test/unit/SFCGAL/algorithm/ApproximateMedialAxis.cpp
+++ b/test/unit/SFCGAL/algorithm/ApproximateMedialAxis.cpp
@@ -1,0 +1,119 @@
+/**
+ *   SFCGAL
+ *
+ *   Copyright (C) 2012-2013 Oslandia <infos@oslandia.com>
+ *   Copyright (C) 2012-2013 IGN (http://www.ign.fr)
+ *
+ *   This library is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Library General Public
+ *   License as published by the Free Software Foundation; either
+ *   version 2 of the License, or (at your option) any later version.
+ *
+ *   This library is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *   Library General Public License for more details.
+
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+#include <boost/test/unit_test.hpp>
+
+#include <SFCGAL/Kernel.h>
+#include <SFCGAL/Point.h>
+#include <SFCGAL/LineString.h>
+#include <SFCGAL/Polygon.h>
+#include <SFCGAL/Triangle.h>
+#include <SFCGAL/PolyhedralSurface.h>
+#include <SFCGAL/TriangulatedSurface.h>
+#include <SFCGAL/Solid.h>
+#include <SFCGAL/GeometryCollection.h>
+#include <SFCGAL/MultiPoint.h>
+#include <SFCGAL/MultiLineString.h>
+#include <SFCGAL/MultiPolygon.h>
+#include <SFCGAL/MultiSolid.h>
+#include <SFCGAL/io/wkt.h>
+#include <SFCGAL/algorithm/straightSkeleton.h>
+
+#include <SFCGAL/detail/tools/Registry.h>
+
+using namespace boost::unit_test ;
+using namespace SFCGAL ;
+
+BOOST_AUTO_TEST_SUITE( SFCGAL_algorithm_ApproximateMedialAxisTest )
+
+
+BOOST_AUTO_TEST_CASE( testTriangle )
+{
+    std::auto_ptr< Geometry > g( io::readWkt( "TRIANGLE((0 0,1 0,1 1,0 0))" ) );
+
+    std::string expectedWKT( "MULTILINESTRING EMPTY");
+    {
+        std::auto_ptr< MultiLineString > result( algorithm::approximateMedialAxis( *g ) ) ;
+        BOOST_CHECK_EQUAL( result->numGeometries(), 0U );
+        BOOST_CHECK_EQUAL( result->asText( 1 ), expectedWKT );
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE( testPolygon )
+{
+    std::auto_ptr< Geometry > g( io::readWkt( "POLYGON((0 0,20 0,20 10,0 10,0 0))" ) );
+
+    std::string expectedWKT( "MULTILINESTRING((5 5,15 5))" );
+    {
+        std::auto_ptr< MultiLineString > result( algorithm::approximateMedialAxis( *g ) ) ;
+        BOOST_CHECK_EQUAL( result->numGeometries(), 1U );
+        BOOST_CHECK_EQUAL( result->asText( 0 ), expectedWKT );
+    }
+}
+BOOST_AUTO_TEST_CASE( testPolygonWithHole )
+{
+    std::auto_ptr< Geometry > g( io::readWkt( "POLYGON((0 0,10 0,10 10,0 10,0 0),(4 4,4 6,6 6,6 4,4 4))" ) );
+
+    std::string expectedWKT( "MULTILINESTRING((2 2,8 2),(2 2,2 8),(8 2,8 8),(2 8,8 8))" );
+    {
+        std::auto_ptr< MultiLineString > result( algorithm::approximateMedialAxis( *g ) ) ;
+        BOOST_CHECK_EQUAL( result->numGeometries(), 4U );
+        BOOST_CHECK_EQUAL( result->asText( 0 ), expectedWKT );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( testPolygonWithTouchingHoles )
+{
+    std::auto_ptr< Geometry > g( io::readWkt( "POLYGON((-1.0 -1.0,1.0 -1.0,1.0 1.0,-1.0 1.0,-1.0 -1.0),(-0.5 -0.5,-0.5 0.5,-0.1 0.5,0.1 -0.5,-0.5 -0.5),(0.1 -0.5,0.1 0.5,0.5 0.5,0.5 -0.5,0.1 -0.5))" ) );
+
+    // just for valgrind
+    BOOST_CHECK_THROW( std::auto_ptr< MultiLineString > result( algorithm::approximateMedialAxis( *g ) ), NotImplementedException ) ;
+
+}
+
+BOOST_AUTO_TEST_CASE( testMultiPolygon )
+{
+    std::auto_ptr< Geometry > g( io::readWkt( "MULTIPOLYGON(((3.000000 0.000000,2.875000 0.484123,2.750000 0.661438,2.625000 0.780625,2.500000 0.866025,2.375000 0.927025,2.250000 0.968246,2.125000 0.992157,2.000000 1.000000,1.875000 1.484123,1.750000 1.661438,1.625000 1.780625,1.500000 1.866025,1.375000 1.927025,1.250000 1.968246,1.125000 1.992157,1.000000 2.000000,0.750000 2.661438,0.500000 2.866025,0.250000 2.968246,0.000000 3.000000,-0.250000 2.968246,-0.500000 2.866025,-0.750000 2.661438,-1.000000 2.000000,-1.125000 1.992157,-1.250000 1.968246,-1.375000 1.927025,-1.500000 1.866025,-1.625000 1.780625,-1.750000 1.661438,-1.875000 1.484123,-2.000000 1.000000,-2.125000 0.992157,-2.250000 0.968246,-2.375000 0.927025,-2.500000 0.866025,-2.625000 0.780625,-2.750000 0.661438,-2.875000 0.484123,-3.000000 0.000000,-2.875000 -0.484123,-2.750000 -0.661438,-2.625000 -0.780625,-2.500000 -0.866025,-2.375000 -0.927025,-2.250000 -0.968246,-2.125000 -0.992157,-2.000000 -1.000000,-1.875000 -1.484123,-1.750000 -1.661438,-1.625000 -1.780625,-1.500000 -1.866025,-1.375000 -1.927025,-1.250000 -1.968246,-1.125000 -1.992157,-1.000000 -2.000000,-0.750000 -2.661438,-0.500000 -2.866025,-0.250000 -2.968246,0.000000 -3.000000,0.250000 -2.968246,0.500000 -2.866025,0.750000 -2.661438,1.000000 -2.000000,1.125000 -1.992157,1.250000 -1.968246,1.375000 -1.927025,1.500000 -1.866025,1.625000 -1.780625,1.750000 -1.661438,1.875000 -1.484123,2.000000 -1.000000,2.125000 -0.992157,2.250000 -0.968246,2.375000 -0.927025,2.500000 -0.866025,2.625000 -0.780625,2.750000 -0.661438,2.875000 -0.484123,3.000000 0.000000),(0.000000 1.000000,0.125000 0.515877,0.250000 0.338562,0.375000 0.219375,0.500000 0.133975,0.625000 0.072975,0.750000 0.031754,0.875000 0.007843,1.000000 0.000000,0.875000 -0.007843,0.750000 -0.031754,0.625000 -0.072975,0.500000 -0.133975,0.375000 -0.219375,0.250000 -0.338562,0.125000 -0.515877,0.000000 -1.000000,-0.125000 -0.515877,-0.250000 -0.338562,-0.375000 -0.219375,-0.500000 -0.133975,-0.625000 -0.072975,-0.750000 -0.031754,-0.875000 -0.007843,-1.000000 0.000000,-0.875000 0.007843,-0.750000 0.031754,-0.625000 0.072975,-0.500000 0.133975,-0.375000 0.219375,-0.250000 0.338562,-0.125000 0.515877,0.000000 1.000000)))" ) );
+    std::auto_ptr< MultiLineString > result( algorithm::approximateMedialAxis( *g ) ) ;
+    BOOST_CHECK_EQUAL( result->numGeometries(), 108U );
+}
+
+
+BOOST_AUTO_TEST_CASE( testInvalidTypes )
+{
+    std::vector< std::string > wkt;
+    wkt.push_back( "POINT(1 2)" );
+    wkt.push_back( "LINESTRING(0 0,1 1)" );
+
+    for ( std::vector< std::string >::const_iterator it=wkt.begin(),
+                                                     itE=wkt.end();
+          it != itE; ++it )
+    {
+      std::auto_ptr< Geometry > g( io::readWkt( *it ) );
+      std::auto_ptr< MultiLineString > result(
+          algorithm::approximateMedialAxis( *g )
+      );
+      BOOST_CHECK_EQUAL( result->numGeometries(), 0U );
+    }
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
Implement an approximateMedialAxis method based on straight skeleton, as described in #76.
Changes ABI (but not API) of the straightSkeleton.h interface.