### PR TITLE
Enable OpenSceneGraph support when available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,17 @@ if( NOT ${GMP_FOUND} OR NOT ${MPFR_FOUND} )
 endif()
 
 
+#-- OpenScenegraph -----------------------------------------
+find_package( OpenSceneGraph COMPONENTS osgDB osgUtil )
+if( ${OPENSCENEGRAPH_FOUND} )
+	message( STATUS "OPENSCENEGRAPH_INCLUDE_DIRS = ${OPENSCENEGRAPH_INCLUDE_DIRS}" )
+	message( STATUS "OPENSCENEGRAPH_LIBRARIES = ${OPENSCENEGRAPH_LIBRARIES}" )
+	set( SFCGAL_WITH_OSG ON )
+
+	include_directories( SYSTEM ${OPENSCENEGRAPH_INCLUDE_DIRS} )
+endif()
+
+
 #-- find CGAL  ---------------------------------------------
 option( CGAL_USE_AUTOLINK "disable CGAL autolink" OFF )
 if( ${CGAL_USE_AUTOLINK} )


### PR DESCRIPTION
With the removal of the viewer in 1.3.0 the OpenSceneGraph support in `CMakeLists.txt` was removed even though OpenSceneGraph can still be used by the library (for `osgWriteFile()` & `toOsgGeometry()`).

This PR restores OpenSceneGraph support in `CMakeLists.txt`, but makes it optional.