### PR TITLE
Fix build failure on i386.

### DIFF
--- a/src/algorithm/connection.h
+++ b/src/algorithm/connection.h
@@ -44,7 +44,7 @@ public:
     typedef size_t VertexIndex;
     typedef size_t FaceIndex;
     typedef std::map< Coordinate, VertexIndex >  CoordinateMap ;
-    static const size_t INVALID_INDEX = size_t( -1 ) ; // would use std::numeric_limits< size_t >::max() if it were constant, or SIZE_MAX if it were easier to find.
+    enum integrals { INVALID_INDEX = size_t( -1 ) } ;
     // an edge is inserted with vtx ordered by the first polygon we treat,
     // we search the edge with reverse ordered vtx indexes.
     // as a result, an inconsistent orientation between polygons can be spotted by


### PR DESCRIPTION
As reported by Dimitri John Ledkov in [Launchpad Bug #1610076](https://bugs.launchpad.net/ubuntu/+source/sfcgal/+bug/1610076) SFCGAL fails to build with g++-6 on i386 (which is also affecting the GCC-6/ICU 57/Boost 1.61 transitions in Debian):
> https://launchpad.net/ubuntu/+source/sfcgal/1.3.0-2build1/+build/10559466
> 
> fails with
> 
> ```
> Leaving test module "UnitTestSFCGAL"; testing time: 29181162us
> 
> *** No errors detected
> *** Error in `/«PKGBUILDDIR»/obj-i686-linux-gnu/test/unit/unit-test-SFCGAL': free(): corrupted unsorted chunks: 0xf8ee64b8 ***
> ======= Backtrace: =========
> /lib/i386-linux-gnu/libc.so.6(+0x672d7)[0xf66662d7]
> /lib/i386-linux-gnu/libc.so.6(+0x6d227)[0xf666c227]
> /lib/i386-linux-gnu/libc.so.6(+0x6dae1)[0xf666cae1]
> /usr/lib/i386-linux-gnu/libstdc++.so.6(_ZdlPv+0x18)[0xf6899518]
> /usr/lib/i386-linux-gnu/libboost_unit_test_framework.so.1.61.0(_ZNSt8_Rb_treeImSt4pairIKmN5boost9unit_test12test_resultsEESt10_Select1stIS5_ESt4lessImESaIS5_EE8_M_eraseEPSt13_Rb_tree_nodeIS5_E+0x135)[0xf6b573a5]
> /usr/lib/i386-linux-gnu/libboost_unit_test_framework.so.1.61.0(+0x4dbcc)[0xf6b56bcc]
> /lib/i386-linux-gnu/libc.so.6(+0x2e933)[0xf662d933]
> /lib/i386-linux-gnu/libc.so.6(+0x2e98f)[0xf662d98f]
> /lib/i386-linux-gnu/libc.so.6(__libc_start_main+0x103)[0xf6617603]
> /«PKGBUILDDIR»/obj-i686-linux-gnu/test/unit/unit-test-SFCGAL(+0xf4ad2)[0xf74bfad2]
> ```
> 
> if one builds with Debug mode, and -O0 the build fails to links due to incorrect declaration & initialization of the static const class member. (Or move initialisation to individual .cpp files and keep only declaration in the header to make sure INVALID_INDEX can be used as both lvalue and rvalue).
> 
> A trivial patch can fix that:
> ```patch
> --- sfcgal-1.3.0.orig/src/algorithm/connection.h
> +++ sfcgal-1.3.0/src/algorithm/connection.h
> @@ -44,7 +44,7 @@ public:
>      typedef size_t VertexIndex;
>      typedef size_t FaceIndex;
>      typedef std::map< Coordinate, VertexIndex >  CoordinateMap ;
> -    static const size_t INVALID_INDEX = size_t( -1 ) ; // would use std::numeric_limits< size_t >::max() if it were constant, or SIZE_MAX if it were easier to find.
> +    enum integrals { INVALID_INDEX = size_t( -1 ) } ;
>      // an edge is inserted with vtx ordered by the first polygon we treat,
>      // we search the edge with reverse ordered vtx indexes.
>      // as a result, an inconsistent orientation between polygons can be spotted by
> ```
> 
> With that compilation succeeds, and test-suite also passes.
> 
> So it does indicate that enabling optimisations results in test-suite failure. Running that under a debuger, only shows that boost-unit-test hits a (double?) free upon tear-down / after exiting a testsuite.
> 
> ```
> /tmp/sfcgal-1.3.0/test/unit/SFCGAL/triangulate/Triangulate2DZTest.cpp(30): Leaving test suite "SFCGAL_triangulate_Triangulate2DZTest"; testing time: 4408us
> Leaving test module "UnitTestSFCGAL"; testing time: 11412502us
> 
> *** No errors detected
> *** Error in `/tmp/sfcgal-1.3.0/obj-i686-linux-gnu/test/unit/unit-test-SFCGAL': free(): corrupted unsorted chunks: 0x5695daa0 ***
> ======= Backtrace: =========
> /lib/i386-linux-gnu/libc.so.6(+0x672d7)[0xf72942d7]
> /lib/i386-linux-gnu/libc.so.6(+0x6d227)[0xf729a227]
> /lib/i386-linux-gnu/libc.so.6(+0x6dae1)[0xf729aae1]
> /usr/lib/i386-linux-gnu/libstdc++.so.6(_ZdlPv+0x18)[0xf74c6518]
> /usr/lib/i386-linux-gnu/libboost_unit_test_framework.so.1.61.0(_ZNSt8_Rb_treeImSt4pairIKmN5boost9unit_test12test_resultsEESt10_Select1stIS5_ESt4lessImESaIS5_EE8_M_eraseEPSt13_Rb_tree_nodeIS5_E+0xfb)[0xf778536b]
> /usr/lib/i386-linux-gnu/libboost_unit_test_framework.so.1.61.0(+0x4dbcc)[0xf7784bcc]
> /lib/i386-linux-gnu/libc.so.6(+0x2e933)[0xf725b933]
> /lib/i386-linux-gnu/libc.so.6(+0x2e98f)[0xf725b98f]
> /lib/i386-linux-gnu/libc.so.6(__libc_start_main+0x103)[0xf7245603]
> /tmp/sfcgal-1.3.0/obj-i686-linux-gnu/test/unit/unit-test-SFCGAL(+0xf4ac2)[0x56649ac2]
> ======= Memory map: ========
> 56555000-56900000 r-xp 00000000 00:28 40093                              /tmp/sfcgal-1.3.0/obj-i686-linux-gnu/test/unit/unit-test-SFCGAL
> 56901000-56907000 r--p 003ab000 00:28 40093                              /tmp/sfcgal-1.3.0/obj-i686-linux-gnu/test/unit/unit-test-SFCGAL
> 56907000-56908000 rw-p 003b1000 00:28 40093                              /tmp/sfcgal-1.3.0/obj-i686-linux-gnu/test/unit/unit-test-SFCGAL
> 56908000-56994000 rw-p 00000000 00:00 0                                  [heap]
> f6700000-f6721000 rw-p 00000000 00:00 0
> f6721000-f6800000 ---p 00000000 00:00 0
> f68bd000-f68d0000 rw-p 00000000 00:00 0
> f68d0000-f68d5000 r-xp 00000000 00:28 2413                               /usr/lib/i386-linux-gnu/libXdmcp.so.6.0.0
> f68d5000-f68d6000 r--p 00004000 00:28 2413                               /usr/lib/i386-linux-gnu/libXdmcp.so.6.0.0
> f68d6000-f68d7000 rw-p 00005000 00:28 2413                               /usr/lib/i386-linux-gnu/libXdmcp.so.6.0.0
> f68d7000-f68d9000 r-xp 00000000 00:28 2400                               /usr/lib/i386-linux-gnu/libXau.so.6.0.0
> f68d9000-f68da000 r--p 00001000 00:28 2400                               /usr/lib/i386-linux-gnu/libXau.so.6.0.0
> f68da000-f68db000 rw-p 00002000 00:28 2400                               /usr/lib/i386-linux-gnu/libXau.so.6.0.0
> f68db000-f68dc000 rw-p 00000000 00:00 0
> f68dc000-f68ec000 r-xp 00000000 00:28 9034                               /usr/lib/i386-linux-gnu/libdrm.so.2.4.0
> f68ec000-f68ed000 r--p 0000f000 00:28 9034                               /usr/lib/i386-linux-gnu/libdrm.so.2.4.0
> f68ed000-f68ee000 rw-p 00010000 00:28 9034                               /usr/lib/i386-linux-gnu/libdrm.so.2.4.0
> f68ee000-f68f3000 r-xp 00000000 00:28 7635                               /usr/lib/i386-linux-gnu/libXxf86vm.so.1.0.0
> f68f3000-f68f4000 r--p 00004000 00:28 7635                               /usr/lib/i386-linux-gnu/libXxf86vm.so.1.0.0
> f68f4000-f68f5000 rw-p 00005000 00:28 7635                               /usr/lib/i386-linux-gnu/libXxf86vm.so.1.0.0
> f68f5000-f6919000 r-xp 00000000 00:28 2426                               /usr/lib/i386-linux-gnu/libxcb.so.1.1.0
> f6919000-f691a000 r--p 00023000 00:28 2426                               /usr/lib/i386-linux-gnu/libxcb.so.1.1.0
> f691a000-f691b000 rw-p 00024000 00:28 2426                               /usr/lib/i386-linux-gnu/libxcb.so.1.1.0
> f691b000-f691f000 r-xp 00000000 00:28 11367                              /usr/lib/i386-linux-gnu/libxcb-dri2.so.0.0.0
> f691f000-f6920000 r--p 00003000 00:28 11367                              /usr/lib/i386-linux-gnu/libxcb-dri2.so.0.0.0
> f6920000-f6921000 rw-p 00004000 00:28 11367                              /usr/lib/i386-linux-gnu/libxcb-dri2.so.0.0.0
> f6921000-f6939000 r-xp 00000000 00:28 11393                              /usr/lib/i386-linux-gnu/libxcb-glx.so.0.0.0
> f6939000-f693a000 ---p 00018000 00:28 11393                              /usr/lib/i386-linux-gnu/libxcb-glx.so.0.0.0
> f693a000-f693b000 r--p 00018000 00:28 11393                              /usr/lib/i386-linux-gnu/libxcb-glx.so.0.0.0
> f693b000-f693c000 rw-p 00019000 00:28 11393                              /usr/lib/i386-linux-gnu/libxcb-glx.so.0.0.0
> f693c000-f693d000 rw-p 00000000 00:00 0
> f693d000-f6a83000 r-xp 00000000 00:28 2700                               /usr/lib/i386-linux-gnu/libX11.so.6.3.0
> f6a83000-f6a84000 ---p 00146000 00:28 2700                               /usr/lib/i386-linux-gnu/libX11.so.6.3.0
> f6a84000-f6a85000 r--p 00146000 00:28 2700                               /usr/lib/i386-linux-gnu/libX11.so.6.3.0
> f6a85000-f6a87000 rw-p 00147000 00:28 2700                               /usr/lib/i386-linux-gnu/libX11.so.6.3.0
> f6a87000-f6a88000 rw-p 00000000 00:00 0
> f6a88000-f6a89000 r-xp 00000000 00:28 11352                              /usr/lib/i386-linux-gnu/libX11-xcb.so.1.0.0
> f6a89000-f6a8a000 r--p 00000000 00:28 11352                              /usr/lib/i386-linux-gnu/libX11-xcb.so.1.0.0
> f6a8a000-f6a8b000 rw-p 00001000 00:28 11352                              /usr/lib/i386-linux-gnu/libX11-xcb.so.1.0.0
> f6a8b000-f6a90000 r-xp 00000000 00:28 11430                              /usr/lib/i386-linux-gnu/libXfixes.so.3.1.0
> f6a90000-f6a91000 r--p 00004000 00:28 11430                              /usr/lib/i386-linux-gnu/libXfixes.so.3.1.0
> f6a91000-f6a92000 rw-p 00005000 00:28 11430                              /usr/lib/i386-linux-gnu/libXfixes.so.3.1.0
> f6a92000-f6a94000 r-xp 00000000 00:28 7598                               /usr/lib/i386-linux-gnu/libXdamage.so.1.1.0
> f6a94000-f6a95000 r--p 00001000 00:28 7598                               /usr/lib/i386-linux-gnu/libXdamage.so.1.1.0
> f6a95000-f6a96000 rw-p 00002000 00:28 7598                               /usr/lib/i386-linux-gnu/libXdamage.so.1.1.0
> f6a96000-f6aa9000 r-xp 00000000 00:28 2717                               /usr/lib/i386-linux-gnu/libXext.so.6.4.0
> f6aa9000-f6aaa000 r--p 00012000 00:28 2717                               /usr/lib/i386-linux-gnu/libXext.so.6.4.0
> f6aaa000-f6aab000 rw-p 00013000 00:28 2717                               /usr/lib/i386-linux-gnu/libXext.so.6.4.0
> f6aab000-f6aac000 rw-p 00000000 00:00 0
> f6aac000-f6abf000 r-xp 00000000 00:28 11336                              /usr/lib/i386-linux-gnu/libglapi.so.0.0.0
> f6abf000-f6ac0000 ---p 00013000 00:28 11336                              /usr/lib/i386-linux-gnu/libglapi.so.0.0.0
> f6ac0000-f6ac2000 r--p 00013000 00:28 11336                              /usr/lib/i386-linux-gnu/libglapi.so.0.0.0
> f6ac2000-f6ac8000 rwxp 00015000 00:28 11336                              /usr/lib/i386-linux-gnu/libglapi.so.0.0.0
> f6ac8000-f6ac9000 r-xp 00000000 00:28 7609                               /usr/lib/i386-linux-gnu/libxshmfence.so.1.0.0
> f6ac9000-f6aca000 r--p 00000000 00:28 7609                               /usr/lib/i386-linux-gnu/libxshmfence.so.1.0.0
> f6aca000-f6acb000 rw-p 00001000 00:28 7609                               /usr/lib/i386-linux-gnu/libxshmfence.so.1.0.0
> f6acb000-f6ad0000 r-xp 00000000 00:28 11419                              /usr/lib/i386-linux-gnu/libxcb-sync.so.1.0.0
> f6ad0000-f6ad1000 ---p 00005000 00:28 11419                              /usr/lib/i386-linux-gnu/libxcb-sync.so.1.0.0
> f6ad1000-f6ad2000 r--p 00005000 00:28 11419                              /usr/lib/i386-linux-gnu/libxcb-sync.so.1.0.0
> f6ad2000-f6ad3000 rw-p 00006000 00:28 11419                              /usr/lib/i386-linux-gnu/libxcb-sync.so.1.0.0
> f6ad3000-f6ad5000 r-xp 00000000 00:28 11406                              /usr/lib/i386-linux-gnu/libxcb-present.so.0.0.0
> f6ad5000-f6ad6000 r--p 00001000 00:28 11406                              /usr/lib/i386-linux-gnu/libxcb-present.so.0.0.0
> f6ad6000-f6ad7000 rw-p 00002000 00:28 11406                              /usr/lib/i386-linux-gnu/libxcb-present.so.0.0.0
> f6ad7000-f6ad9000 r-xp 00000000 00:28 11380                              /usr/lib/i386-linux-gnu/libxcb-dri3.so.0.0.0
> f6ad9000-f6ada000 r--p 00001000 00:28 11380                              /usr/lib/i386-linux-gnu/libxcb-dri3.so.0.0.0
> f6ada000-f6adb000 rw-p 00002000 00:28 11380                              /usr/lib/i386-linux-gnu/libxcb-dri3.so.0.0.0
> f6adb000-f6adc000 rw-p 00000000 00:00 0
> f6adc000-f6b02000 r-xp 00000000 00:28 1361                               /lib/i386-linux-gnu/libexpat.so.1.6.2
> f6b02000-f6b03000 ---p 00026000 00:28 1361                               /lib/i386-linux-gnu/libexpat.so.1.6.2
> f6b03000-f6b05000 r--p 00026000 00:28 1361                               /lib/i386-linux-gnu/libexpat.so.1.6.2
> f6b05000-f6b06000 rw-p 00028000 00:28 1361                               /lib/i386-linux-gnu/libexpat.so.1.6.2
> f6b06000-f6b70000 r-xp 00000000 00:28 11543                              /usr/lib/i386-linux-gnu/mesa/libGL.so.1.2.0
> f6b70000-f6b72000 r--p 00069000 00:28 11543                              /usr/lib/i386-linux-gnu/mesa/libGL.so.1.2.0
> f6b72000-f6b77000 rwxp 0006b000 00:28 11543                              /usr/lib/i386-linux-gnu/mesa/libGL.so.1.2.0
> f6b77000-f6b7e000 r-xp 00000000 08:22 37753073                           /lib/i386-linux-gnu/librt-2.23.so
> f6b7e000-f6b7f000 r--p 00006000 08:22 37753073                           /lib/i386-linux-gnu/librt-2.23.so
> f6b7f000-f6b80000 rw-p 00007000 08:22 37753073                           /lib/i386-linux-gnu/librt-2.23.so
> f6b80000-f6b99000 r-xp 00000000 08:22 37753431                           /lib/i386-linux-gnu/libz.so.1.2.8
> f6b99000-f6b9a000 r--p 00018000 08:22 37753431                           /lib/i386-linux-gnu/libz.so.1.2.8
> f6b9a000-f6b9b000 rw-p 00019000 08:22 37753431                           /lib/i386-linux-gnu/libz.so.1.2.8
> f6b9b000-f6d61000 r-xp 00000000 00:28 34710                              /usr/lib/i386-linux-gnu/libosgUtil.so.3.2.3
> f6d61000-f6d6a000 r--p 001c5000 00:28 34710                              /usr/lib/i386-linux-gnu/libosgUtil.so.3.2.3
> f6d6a000-f6d6b000 rw-p 001ce000 00:28 34710                              /usr/lib/i386-linux-gnu/libosgUtil.so.3.2.3
> f6d6b000-f6d6c000 rw-p 00000000 00:00 0
> f6d6c000-f6d85000 r-xp 00000000 08:22 37753071                           /lib/i386-linux-gnu/libpthread-2.23.so
> f6d85000-f6d86000 r--p 00018000 08:22 37753071                           /lib/i386-linux-gnu/libpthread-2.23.so
> f6d86000-f6d87000 rw-p 00019000 08:22 37753071                           /lib/i386-linux-gnu/libpthread-2.23.so
> f6d87000-f6d89000 rw-p 00000000 00:00 0
> f6d89000-f6d8f000 r-xp 00000000 00:28 34052                              /usr/lib/i386-linux-gnu/libOpenThreads.so.3.2.1
> f6d8f000-f6d90000 ---p 00006000 00:28 34052                              /usr/lib/i386-linux-gnu/libOpenThreads.so.3.2.1
> f6d90000-f6d91000 r--p 00006000 00:28 34052                              /usr/lib/i386-linux-gnu/libOpenThreads.so.3.2.1
> f6d91000-f6d92000 rw-p 00007000 00:28 34052                              /usr/lib/i386-linux-gnu/libOpenThreads.so.3.2.1
> f6d92000-f708d000 r-xp 00000000 00:28 34697                              /usr/lib/i386-linux-gnu/libosg.so.3.2.3
> f708d000-f708e000 ---p 002fb000 00:28 34697                              /usr/lib/i386-linux-gnu/libosg.so.3.2.3
> f708e000-f7097000 r--p 002fb000 00:28 34697                              /usr/lib/i386-linux-gnu/libosg.so.3.2.3
> f7097000-f7098000 rw-p 00304000 00:28 34697                              /usr/lib/i386-linux-gnu/libosg.so.3.2.3
> f7098000-f71a4000 r-xp 00000000 00:28 34699                              /usr/lib/i386-linux-gnu/libosgDB.so.3.2.3
> f71a4000-f71a8000 r--p 0010b000 00:28 34699                              /usr/lib/i386-linux-gnu/libosgDB.so.3.2.3
> f71a8000-f71a9000 rw-p 0010f000 00:28 34699                              /usr/lib/i386-linux-gnu/libosgDB.so.3.2.3
> f71a9000-f7224000 r-xp 00000000 00:28 11390                              /usr/lib/i386-linux-gnu/libCGAL_Core.so.11.0.2
> f7224000-f7225000 ---p 0007b000 00:28 11390                              /usr/lib/i386-linux-gnu/libCGAL_Core.so.11.0.2
> f7225000-f7226000 r--p 0007b000 00:28 11390                              /usr/lib/i386-linux-gnu/libCGAL_Core.so.11.0.2
> f7226000-f7227000 rw-p 0007c000 00:28 11390                              /usr/lib/i386-linux-gnu/libCGAL_Core.so.11.0.2
> f7227000-f7228000 rw-p 00000000 00:00 0
> f7228000-f722b000 r-xp 00000000 08:22 37753060                           /lib/i386-linux-gnu/libdl-2.23.so
> f722b000-f722c000 r--p 00002000 08:22 37753060                           /lib/i386-linux-gnu/libdl-2.23.so
> f722c000-f722d000 rw-p 00003000 08:22 37753060                           /lib/i386-linux-gnu/libdl-2.23.so
> f722d000-f73dc000 r-xp 00000000 08:22 37753055                           /lib/i386-linux-gnu/libc-2.23.so
> f73dc000-f73dd000 ---p 001af000 08:22 37753055                           /lib/i386-linux-gnu/libc-2.23.so
> f73dd000-f73df000 r--p 001af000 08:22 37753055                           /lib/i386-linux-gnu/libc-2.23.so
> f73df000-f73e0000 rw-p 001b1000 08:22 37753055                           /lib/i386-linux-gnu/libc-2.23.so
> f73e0000-f73e3000 rw-p 00000000 00:00 0
> f73e3000-f73ff000 r-xp 00000000 00:28 2416                               /lib/i386-linux-gnu/libgcc_s.so.1
> f73ff000-f7400000 r--p 0001b000 00:28 2416                               /lib/i386-linux-gnu/libgcc_s.so.1
> f7400000-f7401000 rw-p 0001c000 00:28 2416                               /lib/i386-linux-gnu/libgcc_s.so.1
> f7401000-f7454000 r-xp 00000000 08:22 37753061                           /lib/i386-linux-gnu/libm-2.23.so
> f7454000-f7455000 r--p 00052000 08:22 37753061                           /lib/i386-linux-gnu/libm-2.23.so
> f7455000-f7456000 rw-p 00053000 08:22 37753061                           /lib/i386-linux-gnu/libm-2.23.so
> f7456000-f75cc000 r-xp 00000000 00:28 2995                               /usr/lib/i386-linux-gnu/libstdc++.so.6.0.22
> f75cc000-f75d2000 r--p 00175000 00:28 2995                               /usr/lib/i386-linux-gnu/libstdc++.so.6.0.22
> f75d2000-f75d3000 rw-p 0017b000 00:28 2995                               /usr/lib/i386-linux-gnu/libstdc++.so.6.0.22
> f75d3000-f75d7000 rw-p 00000000 00:00 0
> f75d7000-f7661000 r-xp 00000000 08:22 37754829                           /usr/lib/i386-linux-gnu/libgmp.so.10.3.1
> f7661000-f7662000 r--p 00089000 08:22 37754829                           /usr/lib/i386-linux-gnu/libgmp.so.10.3.1
> f7662000-f7663000 rw-p 0008a000 08:22 37754829                           /usr/lib/i386-linux-gnu/libgmp.so.10.3.1
> f7663000-f76ce000 r-xp 00000000 08:22 37754902                           /usr/lib/i386-linux-gnu/libmpfr.so.4.1.4
> f76ce000-f76cf000 r--p 0006a000 08:22 37754902                           /usr/lib/i386-linux-gnu/libmpfr.so.4.1.4
> f76cf000-f76d0000 rw-p 0006b000 08:22 37754902                           /usr/lib/i386-linux-gnu/libmpfr.so.4.1.4
> f76d0000-f76f3000 r-xp 00000000 00:28 11385                              /usr/lib/i386-linux-gnu/libCGAL.so.11.0.2
> f76f3000-f76f4000 r--p 00022000 00:28 11385                              /usr/lib/i386-linux-gnu/libCGAL.so.11.0.2
> f76f4000-f76f5000 rw-p 00023000 00:28 11385                              /usr/lib/i386-linux-gnu/libCGAL.so.11.0.2
> f76f5000-f7734000 r-xp 00000000 00:28 26248                              /usr/lib/i386-linux-gnu/libboost_serialization.so.1.61.0
> f7734000-f7736000 r--p 0003e000 00:28 26248                              /usr/lib/i386-linux-gnu/libboost_serialization.so.1.61.0
> f7736000-f7737000 rw-p 00040000 00:28 26248                              /usr/lib/i386-linux-gnu/libboost_serialization.so.1.61.0
> f7737000-f77e1000 r-xp 00000000 00:28 11416                              /usr/lib/i386-linux-gnu/libboost_unit_test_framework.so.1.61.0
> f77e1000-f77e2000 ---p 000aa000 00:28 11416                              /usr/lib/i386-linux-gnu/libboost_unit_test_framework.so.1.61.0
> f77e2000-f77e4000 r--p 000aa000 00:28 11416                              /usr/lib/i386-linux-gnu/libboost_unit_test_framework.so.1.61.0
> f77e4000-f77e5000 rw-p 000ac000 00:28 11416                              /usr/lib/i386-linux-gnu/libboost_unit_test_framework.so.1.61.0
> f77e5000-f77e7000 rw-p 00000000 00:00 0
> f77e7000-f7fb2000 r-xp 00000000 00:28 39955                              /tmp/sfcgal-1.3.0/obj-i686-linux-gnu/src/libSFCGAL.so.1.3.0
> f7fb2000-f7fc0000 r--p 007ca000 00:28 39955                              /tmp/sfcgal-1.3.0/obj-i686-linux-gnu/src/libSFCGAL.so.1.3.0
> f7fc0000-f7fc1000 rw-p 007d8000 00:28 39955                              /tmp/sfcgal-1.3.0/obj-i686-linux-gnu/src/libSFCGAL.so.1.3.0
> f7fc1000-f7fc2000 rw-p 00000000 00:00 0
> f7fc2000-f7fc3000 r-xp 00000000 08:22 37754648                           /usr/lib/i386-linux-gnu/libeatmydata.so.1.1.2
> f7fc3000-f7fc4000 r--p 00000000 08:22 37754648                           /usr/lib/i386-linux-gnu/libeatmydata.so.1.1.2
> f7fc4000-f7fc5000 rw-p 00001000 08:22 37754648                           /usr/lib/i386-linux-gnu/libeatmydata.so.1.1.2
> f7fd3000-f7fd6000 rw-p 00000000 00:00 0
> f7fd6000-f7fd8000 r--p 00000000 00:00 0                                  [vvar]
> f7fd8000-f7fd9000 r-xp 00000000 00:00 0                                  [vdso]
> f7fd9000-f7ffb000 r-xp 00000000 08:22 37753048                           /lib/i386-linux-gnu/ld-2.23.so
> f7ffb000-f7ffc000 rw-p 00000000 00:00 0
> f7ffc000-f7ffd000 r--p 00022000 08:22 37753048                           /lib/i386-linux-gnu/ld-2.23.so
> f7ffd000-f7ffe000 rw-p 00023000 08:22 37753048                           /lib/i386-linux-gnu/ld-2.23.so
> Program received signal SIGABRT, Aborted.
> 0xf7fd8be9 in __kernel_vsyscall ()
> (gdb) bt full
> #0  0xf7fd8be9 in __kernel_vsyscall ()
> No symbol table info available.
> #1  0xf7258e49 in __GI_raise (sig=6) at ../sysdeps/unix/sysv/linux/raise.c:54
>         resultvar = <optimized out>
>         resultvar = <optimized out>
>         pid = 19907
>         selftid = 19907
> #2  0xf725a3a7 in __GI_abort () at abort.c:89
>         save_stage = 2
>         act = {__sigaction_handler = {sa_handler = 0x78756e69, sa_sigaction = 0x78756e69}, sa_mask = {__val = {1970169645, 761556015, 858926642, 175076142, 1717974886, 808464484, 1714906669, 808478054,
>               2003968048, 807432237, 858927152, 540028976, 842676272, 926097458, 808662327, 538982452, 538976288, 538976288, 538976288, 538976288, 538976288, 538976288, 1768697632, 862531426, 1814902328,
>               2020961897, 1970169645, 761556015, 858926642, 175076142, 0, 4096}}, sa_flags = -148617104, sa_restorer = 0x7}
>         sigs = {__val = {32, 0 <repeats 31 times>}}
> #3  0xf72942dc in __libc_message (do_abort=2, fmt=0xf738cab4 "*** Error in `%s': %s: 0x%s ***\n") at ../sysdeps/posix/libc_fatal.c:175
>         ap = <optimized out>
>         fd = 4
>         on_2 = <optimized out>
>         list = <optimized out>
>         nlist = <optimized out>
>         cp = <optimized out>
>         written = <optimized out>
> #4  0xf729a227 in malloc_printerr (action=<optimized out>, str=0xf738cb8c "free(): corrupted unsorted chunks", ptr=<optimized out>, ar_ptr=0xf73df780 <main_arena>) at malloc.c:5004
>         buf = "5695daa0"
>         cp = <optimized out>
>         ar_ptr = 0xf73df780 <main_arena>
>         ptr = <optimized out>
>         str = 0xf738cb8c "free(): corrupted unsorted chunks"
>         action = <optimized out>
> #5  0xf729aae1 in _int_free (av=0xf73df780 <main_arena>, p=<optimized out>, have_lock=0) at malloc.c:3865
>         size = <optimized out>
>         fb = <optimized out>
>         nextchunk = <optimized out>
>         nextsize = <optimized out>
>         nextinuse = <optimized out>
>         prevsize = <optimized out>
>         bck = <optimized out>
>         fwd = <optimized out>
>         errstr = <optimized out>
>         locked = <optimized out>
>         __func__ = "_int_free"
> #6  0xf74c6518 in operator delete(void*) () from /usr/lib/i386-linux-gnu/libstdc++.so.6
> No symbol table info available.
> #7  0xf778536b in __gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<unsigned long const, boost::unit_test::test_results> > >::deallocate (this=<optimized out>, __p=0x5695daa0)
>     at /usr/include/c++/6/ext/new_allocator.h:110
> No locals.
> #8  std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<unsigned long const, boost::unit_test::test_results> > > >::deallocate (__a=..., __n=1, __p=0x5695daa0)
>     at /usr/include/c++/6/bits/alloc_traits.h:442
> No locals.
> #9  std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_put_node (this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>, __p=0x5695daa0)
>     at /usr/include/c++/6/bits/stl_tree.h:505
> No locals.
> #10 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_drop_node (__p=0x5695daa0, this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>)
>     at /usr/include/c++/6/bits/stl_tree.h:572
> No locals.
> #11 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_erase (__x=0x5695daa0, this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>)
>     at /usr/include/c++/6/bits/stl_tree.h:1610
> No locals.
> #12 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::al---Type <return> to continue, or q <return> to quit---
> locator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_erase (__x=0x56957250, this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>)
>     at /usr/include/c++/6/bits/stl_tree.h:1608
> No locals.
> #13 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_erase (__x=0x5695ddc8, this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>)
>     at /usr/include/c++/6/bits/stl_tree.h:1608
> No locals.
> #14 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_erase (__x=0x5695d460, this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>)
>     at /usr/include/c++/6/bits/stl_tree.h:1608
> No locals.
> #15 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_erase (__x=0x5695b568, this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>)
>     at /usr/include/c++/6/bits/stl_tree.h:1608
> No locals.
> #16 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_erase (__x=0x5695acf0, this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>)
>     at /usr/include/c++/6/bits/stl_tree.h:1608
> No locals.
> #17 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_erase (this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>, __x=0x56950928)
>     at /usr/include/c++/6/bits/stl_tree.h:1608
> No locals.
> #18 0xf7784bcc in std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::_M_erase (__x=0x5694f7e8, this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>)
>     at /usr/include/c++/6/bits/stl_tree.h:1608
> No locals.
> #19 std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::unit_test::test_results>, std::_Select1st<std::pair<unsigned long const, boost::unit_test::test_results> >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::~_Rb_tree (this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>, __in_chrg=<optimized out>)
>     at /usr/include/c++/6/bits/stl_tree.h:868
> No locals.
> #20 std::map<unsigned long, boost::unit_test::test_results, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, boost::unit_test::test_results> > >::~map (
>     this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>, __in_chrg=<optimized out>) at /usr/include/c++/6/bits/stl_map.h:96
> No locals.
> #21 boost::unit_test::(anonymous namespace)::results_collector_impl::~results_collector_impl (this=0xf77e5c38 <boost::unit_test::(anonymous namespace)::s_rc_impl()::the_inst>, __in_chrg=<optimized out>)
>     at ./boost/test/impl/results_collector.ipp:114
> No locals.
> #22 0xf725b933 in __run_exit_handlers (status=0, listp=0xf73df3dc <__exit_funcs>, run_list_atexit=true) at exit.c:82
>         atfct = <optimized out>
>         onfct = <optimized out>
>         cxafct = <optimized out>
> #23 0xf725b98f in __GI_exit (status=0) at exit.c:104
> No locals.
> #24 0xf7245603 in __libc_start_main (main=0x566499e0 <main(int, char**)>, argc=1, argv=0xffffd624, init=0x56875a50 <__libc_csu_init>, fini=0x56875ab0 <__libc_csu_fini>, rtld_fini=0xf7fe8780 <_dl_fini>,
>     stack_end=0xffffd61c) at ../csu/libc-start.c:325
>         result = <optimized out>
>         unwind_buf = {cancel_jmp_buf = {{jmp_buf = {0, -146935808, -146935808, 0, -1202387646, 257248083}, mask_was_saved = 0}}, priv = {pad = {0x0, 0x0, 0xffffd620, 0xf7fd9000}, data = {prev = 0x0,
>               cleanup = 0x0, canceltype = -10720}}}
>         not_first_call = <optimized out>
> #25 0x56649ac2 in _start ()
> No symbol table info available.
> ```
> 
> I am confused as to what is going on.

And from the [first comment of the Launchpad](https://bugs.launchpad.net/ubuntu/+source/sfcgal/+bug/1610076/comments/1) issue:
> ```
> ==2697== Warning: client switching stacks? SP change: 0x600f280 --> 0xfec0a100
> ==2697== to suppress, use: --max-stackframe=121655680 or greater
> unknown location(0): fatal error: in "SFCGAL_algorithm_IntersectionTest/testFileIntersectionTest": memory access violation at address: 0xbbb1d800: no mapping at fault address
> /tmp/sfcgal-1.3.0/test/unit/SFCGAL/algorithm/IntersectionTest.cpp(227): last checkpoint
> Test is aborted
> /tmp/sfcgal-1.3.0/test/unit/SFCGAL/algorithm/IntersectionTest.cpp(67): Leaving test case "testFileIntersectionTest"; testing time: 69400776us
> Test is aborted
> /tmp/sfcgal-1.3.0/test/unit/SFCGAL/algorithm/IntersectionTest.cpp(65): Leaving test suite "SFCGAL_algorithm_IntersectionTest"; testing time: 69402508us
> Test is aborted
> Leaving test module "UnitTestSFCGAL"; testing time: 93720212us
> ```
> 
> Probably things are asynchronous and going out of scope =( *sigh*

This PR forwards Dimitris patch that fixes the build failure on i386.