### PR TITLE
Add missing boost lib requirements in tests and examples

### DIFF
--- a/example/CGAL-basic_manip/CMakeLists.txt
+++ b/example/CGAL-basic_manip/CMakeLists.txt
@@ -2,6 +2,7 @@ GET_FILENAME_COMPONENT( EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
 add_executable( example-${EXAMPLE_NAME} 
 	main.cpp 
 )
-target_link_libraries( example-${EXAMPLE_NAME} SFCGAL)
+find_package(Boost REQUIRED COMPONENTS serialization)
+target_link_libraries( example-${EXAMPLE_NAME} SFCGAL ${Boost_LIBRARIES})
 set_target_properties( example-${EXAMPLE_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS example-${EXAMPLE_NAME} DESTINATION bin )

--- a/example/CGAL-cartesian_kernel/CMakeLists.txt
+++ b/example/CGAL-cartesian_kernel/CMakeLists.txt
@@ -2,6 +2,7 @@ GET_FILENAME_COMPONENT( EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
 add_executable( example-${EXAMPLE_NAME} 
 	main.cpp 
 )
-target_link_libraries( example-${EXAMPLE_NAME} SFCGAL)
+find_package(Boost REQUIRED COMPONENTS serialization)
+target_link_libraries( example-${EXAMPLE_NAME} SFCGAL ${Boost_LIBRARIES})
 set_target_properties( example-${EXAMPLE_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS example-${EXAMPLE_NAME} DESTINATION bin )

--- a/example/CGAL-point_generator/CMakeLists.txt
+++ b/example/CGAL-point_generator/CMakeLists.txt
@@ -2,6 +2,7 @@ GET_FILENAME_COMPONENT( EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
 add_executable( example-${EXAMPLE_NAME} 
 	main.cpp 
 )
-target_link_libraries( example-${EXAMPLE_NAME} SFCGAL)
+find_package(Boost REQUIRED COMPONENTS serialization)
+target_link_libraries( example-${EXAMPLE_NAME} SFCGAL ${Boost_LIBRARIES})
 set_target_properties( example-${EXAMPLE_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS example-${EXAMPLE_NAME} DESTINATION bin )

--- a/example/CGAL-polygon_triangulation2/CMakeLists.txt
+++ b/example/CGAL-polygon_triangulation2/CMakeLists.txt
@@ -2,6 +2,7 @@ GET_FILENAME_COMPONENT( EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
 add_executable( example-${EXAMPLE_NAME} 
 	main.cpp 
 )
-target_link_libraries( example-${EXAMPLE_NAME} SFCGAL)
+find_package(Boost REQUIRED COMPONENTS serialization)
+target_link_libraries( example-${EXAMPLE_NAME} SFCGAL ${Boost_LIBRARIES})
 set_target_properties( example-${EXAMPLE_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS example-${EXAMPLE_NAME} DESTINATION bin )

--- a/example/CGAL-triangulation2/CMakeLists.txt
+++ b/example/CGAL-triangulation2/CMakeLists.txt
@@ -2,6 +2,7 @@ GET_FILENAME_COMPONENT( EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
 add_executable( example-${EXAMPLE_NAME} 
 	main.cpp 
 )
-target_link_libraries( example-${EXAMPLE_NAME} SFCGAL)
+find_package(Boost REQUIRED COMPONENTS serialization)
+target_link_libraries( example-${EXAMPLE_NAME} SFCGAL ${Boost_LIBRARIES})
 set_target_properties( example-${EXAMPLE_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS example-${EXAMPLE_NAME} DESTINATION bin )

--- a/example/SFCGAL-building/CMakeLists.txt
+++ b/example/SFCGAL-building/CMakeLists.txt
@@ -2,6 +2,8 @@ GET_FILENAME_COMPONENT( EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
 add_executable( example-${EXAMPLE_NAME} 
 	main.cpp 
 )
-target_link_libraries( example-${EXAMPLE_NAME} SFCGAL SFCGAL-osg)
+
+find_package(Boost REQUIRED COMPONENTS serialization)
+target_link_libraries( example-${EXAMPLE_NAME} SFCGAL ${Boost_LIBRARIES} SFCGAL-osg)
 set_target_properties( example-${EXAMPLE_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS example-${EXAMPLE_NAME} DESTINATION bin )

--- a/example/SFCGAL-export-osg/CMakeLists.txt
+++ b/example/SFCGAL-export-osg/CMakeLists.txt
@@ -2,6 +2,7 @@ GET_FILENAME_COMPONENT( EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
 add_executable( example-${EXAMPLE_NAME} 
 	main.cpp 
 )
-target_link_libraries( example-${EXAMPLE_NAME} SFCGAL SFCGAL-osg)
+find_package(Boost REQUIRED COMPONENTS serialization)
+target_link_libraries( example-${EXAMPLE_NAME} SFCGAL SFCGAL-osg ${Boost_LIBRARIES})
 set_target_properties( example-${EXAMPLE_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS example-${EXAMPLE_NAME} DESTINATION bin )

--- a/example/SFCGAL-offset/CMakeLists.txt
+++ b/example/SFCGAL-offset/CMakeLists.txt
@@ -2,6 +2,7 @@ GET_FILENAME_COMPONENT( EXAMPLE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
 add_executable( example-${EXAMPLE_NAME} 
 	main.cpp 
 )
-target_link_libraries( example-${EXAMPLE_NAME} SFCGAL)
+find_package(Boost REQUIRED COMPONENTS serialization)
+target_link_libraries( example-${EXAMPLE_NAME} SFCGAL ${Boost_LIBRARIES})
 set_target_properties( example-${EXAMPLE_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS example-${EXAMPLE_NAME} DESTINATION bin )

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -1,6 +1,9 @@
 file( GLOB SFCGAL_BENCHS_SOURCES *.cpp )
 add_executable( bench-SFCGAL ${SFCGAL_BENCHS_SOURCES} )
-target_link_libraries( bench-SFCGAL SFCGAL)
+
+find_package(Boost REQUIRED COMPONENTS unit_test_framework timer serialization)
+
+target_link_libraries( bench-SFCGAL SFCGAL ${Boost_LIBRARIES})
 set_target_properties( bench-SFCGAL PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS bench-SFCGAL DESTINATION bin )
 

--- a/test/garden/CMakeLists.txt
+++ b/test/garden/CMakeLists.txt
@@ -1,11 +1,13 @@
 #-- polygon_triangulator test
 file( GLOB_RECURSE SFCGAL_REGRESS_GARDEN_TEST_SOURCES *.cpp )
 
+find_package(Boost REQUIRED COMPONENTS program_options serialization)
+
 set( REGRESS_NAME garden-test-SFCGAL )
 add_executable( ${REGRESS_NAME} ${SFCGAL_REGRESS_GARDEN_TEST_SOURCES} )
 
 target_link_libraries( ${REGRESS_NAME} SFCGAL)
-target_link_libraries( ${REGRESS_NAME} ${CGAL_3RD_PARTY_LIBRARIES} )
+target_link_libraries( ${REGRESS_NAME} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES})
 
 set_target_properties( ${REGRESS_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS ${REGRESS_NAME} DESTINATION bin )

--- a/test/regress/convex_hull/CMakeLists.txt
+++ b/test/regress/convex_hull/CMakeLists.txt
@@ -4,9 +4,11 @@ file( GLOB_RECURSE SFCGAL_REGRESS_CONVEX_HULL_TEST_SOURCES *.cpp )
 set( REGRESS_NAME test-regress-convex_hull )
 add_executable( ${REGRESS_NAME} ${SFCGAL_REGRESS_CONVEX_HULL_TEST_SOURCES} )
 
+find_package(Boost REQUIRED COMPONENTS program_options filesystem serialization)
+
 target_link_libraries( ${REGRESS_NAME} SFCGAL)
 
-target_link_libraries( ${REGRESS_NAME} ${CGAL_3RD_PARTY_LIBRARIES} )
+target_link_libraries( ${REGRESS_NAME} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES})
 
 set_target_properties( ${REGRESS_NAME} PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS ${REGRESS_NAME} DESTINATION bin )

--- a/test/regress/polygon_triangulator/CMakeLists.txt
+++ b/test/regress/polygon_triangulator/CMakeLists.txt
@@ -4,8 +4,10 @@ file( GLOB_RECURSE SFCGAL_REGRESS_POLYGON_TRIANGULATOR_TEST_SOURCES *.cpp )
 set( REGRESS_NAME test-regress-polygon_triangulator )
 add_executable( ${REGRESS_NAME} ${SFCGAL_REGRESS_POLYGON_TRIANGULATOR_TEST_SOURCES} )
 
+find_package(Boost REQUIRED COMPONENTS program_options filesystem serialization)
+
 target_link_libraries( ${REGRESS_NAME}	SFCGAL)
-target_link_libraries( ${REGRESS_NAME} ${CGAL_3RD_PARTY_LIBRARIES})
+target_link_libraries( ${REGRESS_NAME} ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES})
 
 
 set_target_properties( ${REGRESS_NAME} PROPERTIES DEBUG_POSTFIX "d" )

--- a/test/regress/standalone/CMakeLists.txt
+++ b/test/regress/standalone/CMakeLists.txt
@@ -2,7 +2,9 @@
 file( GLOB_RECURSE SFCGAL_REGRESS_STANDALONE_TEST_SOURCES *.cpp )
 add_executable( standalone-regress-test-SFCGAL ${SFCGAL_REGRESS_STANDALONE_TEST_SOURCES} )
 
-target_link_libraries( standalone-regress-test-SFCGAL SFCGAL)
+find_package(Boost REQUIRED COMPONENTS unit_test_framework filesystem serialization)
+
+target_link_libraries( standalone-regress-test-SFCGAL SFCGAL ${Boost_LIBRARIES})
 
 set_target_properties( standalone-regress-test-SFCGAL PROPERTIES DEBUG_POSTFIX "d" )
 install( TARGETS standalone-regress-test-SFCGAL DESTINATION bin )

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,8 +1,11 @@
 #-- build unit tests
+
+find_package(Boost REQUIRED COMPONENTS unit_test_framework serialization)
+
 file( GLOB_RECURSE SFCGAL_UNIT_TEST_SOURCES *.cpp )
 add_executable( unit-test-SFCGAL ${SFCGAL_UNIT_TEST_SOURCES} )
 target_link_libraries( unit-test-SFCGAL SFCGAL)
-target_link_libraries(unit-test-SFCGAL ${CGAL_3RD_PARTY_LIBRARIES})
+target_link_libraries(unit-test-SFCGAL ${CGAL_3RD_PARTY_LIBRARIES} ${Boost_LIBRARIES})
 
 #include( PrecompiledHeader )
 #if(PCHSupport_FOUND)


### PR DESCRIPTION
Should fix #166 and #167 

If you want to keep using a `FindSFCGAL.cmake`, you should add boost serialization as required dependencies in there. If you move to cmake config mode, then you could add boost serialization as a target to link with for SFCGAL. `program_options`, `unit_test_frameworks`, ... are only required by tests and examples and should stay IMO as is in the tests.
