### PR TITLE
Fix mismatch between declaration in headers and actual function name in C API

### DIFF
--- a/src/capi/sfcgal_c.h
+++ b/src/capi/sfcgal_c.h
@@ -471,7 +471,7 @@ SFCGAL_API const sfcgal_geometry_t*  sfcgal_solid_shell_n( const sfcgal_geometry
  * @post the ownership of the shell is taken. The caller is not responsible anymore of its deallocation
  * @ingroup capi
  */
-SFCGAL_API void                      sfcgal_solid_add_shell( sfcgal_geometry_t* solid, sfcgal_geometry_t* shell );
+SFCGAL_API void                      sfcgal_solid_add_interior_shell( sfcgal_geometry_t* solid, sfcgal_geometry_t* shell );
 
 
 /**


### PR DESCRIPTION
There is a mismatch between the implementation file and the header file when declaring the function `sfcgal_solid_add_interior_shell` :

 https://github.com/Oslandia/SFCGAL/blob/3208a7b28e35f78430af07ad7839ad7d697eea49/src/capi/sfcgal_c.cpp#L562

https://github.com/Oslandia/SFCGAL/blob/3208a7b28e35f78430af07ad7839ad7d697eea49/src/capi/sfcgal_c.h#L474

This PR propose to fix it by changing `sfcgal_solid_add_shell` to  `sfcgal_solid_add_interior_shell` in the header file.