### PR TITLE
Vs2019 fixes

### DIFF
--- a/src/detail/ComplexComparator.h
+++ b/src/detail/ComplexComparator.h
@@ -33,7 +33,7 @@ namespace detail {
  */
 struct SFCGAL_API ComplexComparator {
     template < typename T >
-    inline bool operator () ( const std::complex< T >& a, const std::complex< T >& b ) {
+    inline bool operator () ( const std::complex< T >& a, const std::complex< T >& b ) const {
         return ( a.real() < b.real() ) || ( a.real() == b.real() && a.imag() < b.imag() );
     }
 };

--- a/test/regress/standalone/SFCGAL/StraightSkeletonTest.cpp
+++ b/test/regress/standalone/SFCGAL/StraightSkeletonTest.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_SUITE( SFCGAL_StraightSkeletonTest )
 
 namespace {
 
-    void runTest(const std::string& filename)
+    void runTest(const boost::filesystem::path::string_type& filename)
     {
         std::ifstream ifs( filename.c_str() );
         BOOST_REQUIRE( ifs.good() ) ;


### PR DESCRIPTION
Compilation fixes for Visual Studio 2019 (VC142) with Boost 1.70.