### PR TITLE
Fix CMake scripts so that SFCGAL_USE_STATIC_LIBS works properly again.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,13 @@ if((${Boost_MAJOR_VERSION} EQUAL 1) AND (${Boost_MINOR_VERSION} EQUAL 60) AND ($
   include_directories( patches/boost-1.60.0 )
 endif()
 
+if( SFCGAL_USE_STATIC_LIBS )
+  add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+  if (NOT MSVC)
+    add_definitions( "-fPIC" )
+  endif()
+endif()
+
 #-- OpenScenegraph -----------------------------------------
 if ( SFCGAL_WITH_OSG )
   find_package( OpenSceneGraph COMPONENTS osgDB osgUtil )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,10 @@ list(REMOVE_ITEM SFCGAL_HEADERS ${SFCGAL_OSG_HEADERS})
 list(REMOVE_ITEM SFCGAL_SOURCES ${SFCGAL_OSG_SOURCES})
 
 if( SFCGAL_USE_STATIC_LIBS )
-  add_definitions( "-fPIC" )
+  add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+  if (NOT MSVC)
+    add_definitions( "-fPIC" )
+  endif()
   add_library(
     SFCGAL
     ${SFCGAL_HEADERS}
@@ -77,7 +80,10 @@ install(
 # SFCGAL-osg
 if ( SFCGAL_WITH_OSG )
   if( SFCGAL_USE_STATIC_LIBS )
-    add_definitions( "-fPIC" )
+    add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+    if (NOT MSVC)
+      add_definitions( "-fPIC" )
+    endif()
     add_library(
       SFCGAL-osg
       ${SFCGAL_OSG_HEADERS}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,9 @@
 #-- configure tests
+
+if( SFCGAL_USE_STATIC_LIBS )
+  add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+endif()
+
 set( SFCGAL_TEST_DIRECTORY "${CMAKE_SOURCE_DIR}/test" )
 configure_file( ${SFCGAL_TEST_DIRECTORY}/test_config.h.cmake ${SFCGAL_TEST_DIRECTORY}/test_config.h )
 

--- a/test/garden/CMakeLists.txt
+++ b/test/garden/CMakeLists.txt
@@ -1,4 +1,9 @@
 #-- polygon_triangulator test
+
+if( SFCGAL_USE_STATIC_LIBS )
+  add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+endif()
+
 file( GLOB_RECURSE SFCGAL_REGRESS_GARDEN_TEST_SOURCES *.cpp )
 
 find_package(Boost REQUIRED COMPONENTS program_options serialization)

--- a/test/regress/convex_hull/CMakeLists.txt
+++ b/test/regress/convex_hull/CMakeLists.txt
@@ -1,4 +1,9 @@
 #-- polygon_triangulator test
+
+if( SFCGAL_USE_STATIC_LIBS )
+  add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+endif()
+
 file( GLOB_RECURSE SFCGAL_REGRESS_CONVEX_HULL_TEST_SOURCES *.cpp )
 
 set( REGRESS_NAME test-regress-convex_hull )

--- a/test/regress/polygon_triangulator/CMakeLists.txt
+++ b/test/regress/polygon_triangulator/CMakeLists.txt
@@ -1,4 +1,9 @@
 #-- polygon_triangulator test
+
+if( SFCGAL_USE_STATIC_LIBS )
+  add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+endif()
+
 file( GLOB_RECURSE SFCGAL_REGRESS_POLYGON_TRIANGULATOR_TEST_SOURCES *.cpp )
 
 set( REGRESS_NAME test-regress-polygon_triangulator )

--- a/test/regress/standalone/CMakeLists.txt
+++ b/test/regress/standalone/CMakeLists.txt
@@ -1,4 +1,9 @@
 #-- standalone test
+
+if( SFCGAL_USE_STATIC_LIBS )
+  add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+endif()
+
 file( GLOB_RECURSE SFCGAL_REGRESS_STANDALONE_TEST_SOURCES *.cpp )
 add_executable( standalone-regress-test-SFCGAL ${SFCGAL_REGRESS_STANDALONE_TEST_SOURCES} )
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -2,6 +2,10 @@
 
 find_package(Boost REQUIRED COMPONENTS unit_test_framework serialization)
 
+if( SFCGAL_USE_STATIC_LIBS )
+  add_definitions( "-DSFCGAL_USE_STATIC_LIBS" )
+endif()
+
 file( GLOB_RECURSE SFCGAL_UNIT_TEST_SOURCES *.cpp )
 add_executable( unit-test-SFCGAL ${SFCGAL_UNIT_TEST_SOURCES} )
 target_link_libraries( unit-test-SFCGAL SFCGAL)


### PR DESCRIPTION
Fixed CMake scripts so that SFCGAL_USE_STATIC_LIBS works properly again.

Removed -fPIC option under MSVC as it is not recognised.