### PR TITLE
algorithm: Intersection3D: fix include of nonexisting file

### DIFF
--- a/src/algorithm/Intersection3D.cpp
+++ b/src/algorithm/Intersection3D.cpp
@@ -31,7 +31,6 @@
 #include <SFCGAL/detail/triangulate/triangulateInGeometrySet.h>
 
 #include <CGAL/IO/Polyhedron_iostream.h>
-#include <CGAL/Polygon_mesh_processing/corefinement.h>
 
 #include <SFCGAL/detail/Point_inside_polyhedron.h>
 


### PR DESCRIPTION
The included file from CGAL doesn't exist there. I could not find
when it ceased to exist, or whether it did already exist in the
first place.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>