### PR TITLE
add pkg-config descriptor file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,3 +228,6 @@ endif()
 #set( SFCGAL_LIB_NAME ${${CMAKE_BUILD_TYPE}
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sfcgal-config.in ${CMAKE_CURRENT_BINARY_DIR}/sfcgal-config @ONLY)
 install( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/sfcgal-config DESTINATION bin )
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sfcgal.pc.in ${CMAKE_CURRENT_BINARY_DIR}/sfcgal.pc @ONLY)
+install( FILES ${CMAKE_CURRENT_BINARY_DIR}/sfcgal.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/sfcgal.pc.in
+++ b/sfcgal.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: sfcgal
+Description: A wrapper around CGAL that intents to implement 2D and 3D operations on OGC standards models
+Version: @SFCGAL_VERSION@
+Libs: -L${libdir} -l@SFCGAL_LIB_NAME@
+Cflags: -I${includedir}


### PR DESCRIPTION
Create/install a pkgconfig descriptor (.pc file), so that other
packages can easily find us.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>