### PR TITLE
algorithm: distance3d: fix result type comparison of CGAL::intersection

### DIFF
--- a/src/algorithm/distance3d.cpp
+++ b/src/algorithm/distance3d.cpp
@@ -763,7 +763,7 @@ squared_distance_t squaredDistanceSegmentTriangle3D(
     /*
      * If [sAsB] intersects the triangle (tA,tB,tC), distance is 0.0
      */
-    if ( boost::none != CGAL::intersection( sAB, tABC ) ) {
+    if ( CGAL::intersection( sAB, tABC ) ) {
         return 0.0 ;
     }
 
@@ -821,7 +821,7 @@ squared_distance_t squaredDistanceTriangleTriangle3D(
     const Triangle_3& triangleB
 )
 {
-    if ( boost::none != CGAL::intersection( triangleA, triangleB ) ) {
+    if ( CGAL::intersection( triangleA, triangleB ) ) {
         return squared_distance_t( 0 );
     }
 


### PR DESCRIPTION
CGAL::intersection returns bool, so just simple 'if' instead of comparing
with 'boost::none', which isn't comparable to 'bool'.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>