### PR TITLE
Libtoolize.cmake: fix broken create_libtool_file() macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/include DESTINATION .)
 
 
 #-- create a libtool file for SFCGAL (needed by PostGIS)
-create_libtool_file( SFCGAL /lib )
+create_libtool_file( SFCGAL )
 
 #-- sfcgal-config
 if ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )

--- a/cmake/Modules/Libtoolize.cmake
+++ b/cmake/Modules/Libtoolize.cmake
@@ -5,7 +5,7 @@ MACRO(GET_TARGET_PROPERTY_WITH_DEFAULT _variable _target _property _default_valu
    ENDIF (${_variable} MATCHES NOTFOUND)
  ENDMACRO (GET_TARGET_PROPERTY_WITH_DEFAULT)
 
- MACRO(CREATE_LIBTOOL_FILE _target _install_DIR)
+MACRO(CREATE_LIBTOOL_FILE _target)
    GET_TARGET_PROPERTY(_target_location ${_target} LOCATION)
    GET_TARGET_PROPERTY_WITH_DEFAULT(_target_static_lib ${_target} STATIC_LIB "")
    GET_TARGET_PROPERTY_WITH_DEFAULT(_target_dependency_libs ${_target} LT_DEPENDENCY_LIBS "")
@@ -44,6 +44,6 @@ MACRO(GET_TARGET_PROPERTY_WITH_DEFAULT _variable _target _property _default_valu
    FILE(APPEND ${_laname} "dlopen='${_target_dlopen}'\n")
    FILE(APPEND ${_laname} "dlpreopen='${_target_dlpreopen}'\n\n")
    FILE(APPEND ${_laname} "# Directory that this library needs to be installed in:\n")
-   FILE(APPEND ${_laname} "libdir='${CMAKE_INSTALL_PREFIX}${_install_DIR}'\n")
-   INSTALL( FILES ${_laname} DESTINATION ${CMAKE_INSTALL_PREFIX}${_install_DIR})
- ENDMACRO(CREATE_LIBTOOL_FILE)
+   FILE(APPEND ${_laname} "libdir='${CMAKE_INSTALL_LIBDIR}'\n")
+   INSTALL( FILES ${_laname} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ENDMACRO(CREATE_LIBTOOL_FILE)


### PR DESCRIPTION
The .la files are installed in hardcoded at location at:
   ${CMAKE_INSTALL_PREFIX}/lib

This is completely wrong on most distros - especially 64 bit, where
libraries are placed at /lib64 or /usr/lib64.

Fixing to use ${CMAKE_INSTALL_LIBDIR}, so the files are placed into
the library directory given by the packager / operator.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>