### PR TITLE
Fix CGAL v4.7 compatibility

### DIFF
--- a/src/algorithm/Intersection3D.cpp
+++ b/src/algorithm/Intersection3D.cpp
@@ -192,7 +192,7 @@ void _intersection_solid_triangle( const MarkedPolyhedron& pa, const CGAL::Trian
     // triangle decomposition
     std::list<MarkedPolyhedron> decomposition;
     Is_not_marked criterion;
-#if CGAL_VERSION_NR < 1040701000 // version 4.7
+#if CGAL_VERSION_NR < 1040700000 // version 4.7
     // Before 4.7, extract_connected_components lies in CGAL::internal
     CGAL::internal::extract_connected_components( polyb, criterion, std::back_inserter( decomposition ) );
 #else

--- a/src/detail/Point_inside_polyhedron.h
+++ b/src/detail/Point_inside_polyhedron.h
@@ -4,7 +4,7 @@
 //
 // Compatibility layer for Point_inside_polyhderon_3 that becomes Side_of_triangle_mesh in CGAL 4.7
 
-#if CGAL_VERSION_NR < 1040701000 // version 4.7
+#if CGAL_VERSION_NR < 1040700000 // version 4.7
 
 #include <CGAL/Point_inside_polyhedron_3.h>
 #define Point_inside_polyhedron CGAL::Point_inside_polyhedron_3


### PR DESCRIPTION
The special handlings for cgal v4.7 are required since v4.7.0,
instead of v4.7.1.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>