### PR TITLE
algorithm: distance3d: fix result type comparison of CGAL::intersection v2

### DIFF
--- a/src/algorithm/distance3d.cpp
+++ b/src/algorithm/distance3d.cpp
@@ -763,9 +763,8 @@ squared_distance_t squaredDistanceSegmentTriangle3D(
     /*
      * If [sAsB] intersects the triangle (tA,tB,tC), distance is 0.0
      */
-    if ( boost::none != CGAL::intersection( sAB, tABC ) ) {
+    if ( CGAL::do_intersect( sAB, tABC ) )
         return 0.0 ;
-    }
 
     /*
      * else, distance is the min of the following values :
@@ -821,9 +820,8 @@ squared_distance_t squaredDistanceTriangleTriangle3D(
     const Triangle_3& triangleB
 )
 {
-    if ( boost::none != CGAL::intersection( triangleA, triangleB ) ) {
+    if ( CGAL::do_intersect( triangleA, triangleB ) )
         return squared_distance_t( 0 );
-    }
 
     /*
      * min of distance from A segments to B triangle and B segments to A triangle


### PR DESCRIPTION
CGAL::intersection returns bool, so just simple 'if' instead of comparing
with 'boost::none', which isn't comparable to 'bool'.

Following Laurent Rineau's suggestion to call do_intersect() instead.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>