### PR TITLE
Issue #195: Exposed structors of SFCGAL::Geometry as public.

### DIFF
--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -40,15 +40,6 @@ namespace SFCGAL {
 ///
 ///
 ///
-Geometry::~Geometry()
-{
-
-}
-
-
-///
-///
-///
 std::string Geometry::asText( const int& numDecimals ) const
 {
     std::ostringstream oss;
@@ -144,27 +135,12 @@ Geometry&   Geometry::geometryN( size_t const& n )
     return *this ;
 }
 
-
 ///
 ///
 ///
 Geometry::Geometry() : validityFlag_( false )
 {
 
-}
-
-///
-///
-///
-Geometry::Geometry( Geometry const& other ) : validityFlag_( other.validityFlag_ )
-{
-
-}
-
-Geometry& Geometry::operator=( const Geometry& other )
-{
-    validityFlag_ = other.validityFlag_;
-    return *this;
 }
 
 bool Geometry::hasValidityFlag() const

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -116,7 +116,26 @@ typedef enum {
  */
 class SFCGAL_API Geometry {
 public:
-    virtual ~Geometry();
+
+    /**
+     * @brief Default constructor.
+     */
+    Geometry();
+
+    /**
+     * @brief Copy constructor.
+     */
+    Geometry( const Geometry& ) = default;
+
+    /**
+     * @brief Copy assignemnt operator.
+     */
+    Geometry& operator=( const Geometry& other ) = default;
+
+    /**
+     * @brief Destructor.
+     */
+    virtual ~Geometry() = default;
 
     /**
      * @brief Get a deep copy of the geometry
@@ -279,10 +298,8 @@ public:
     template <class Archive>
     void serialize( Archive& /*ar*/, const unsigned int /*version*/ ) {
     }
+
 protected:
-    Geometry();
-    Geometry( const Geometry& );
-    Geometry& operator=( const Geometry& other );
 
     bool validityFlag_;
 };


### PR DESCRIPTION
* The SFCGAL::Geometry class is abstract, hence exposing
  it as public will still not endow clients with any
  enhanced ability to construct concrete SFCGAL::Geometry
  objects, except through subclasses, which have always had
  access to this (protected) constructor in any case.

* There is no need for explicit mplementations of the
  structors since the default behaviours achieve the same
  result.