### PR TITLE
Fix SFCGAL with CGAL 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler:
   - clang
 
 env:
-  - CGAL_VERSION=4.13
+  - CGAL_VERSION=5.0.2
 
 before_install:
   - ./travis/${TRAVIS_OS_NAME}/before_install.sh $CGAL_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required( VERSION 2.8 )
 project( SFCGAL )
 
 set( CMAKE_DEBUG_POSTFIX "d" )
+set(CMAKE_CXX_STANDARD 14)
 
 #----------------------------------------------------------------------------
 # build options
@@ -53,6 +54,10 @@ endif()
 # 4.13 recommended
 find_package( CGAL COMPONENTS Core REQUIRED )
 message( STATUS "CGAL ${CGAL_VERSION} found" )
+
+if( "${CGAL_VERSION}" VERSION_GREATER_EQUAL "5.0.0")
+add_definitions( "-DCGAL_USE_GMPXX=1" )
+endif()
 
 include_directories( ${CMAKE_BINARY_DIR}/include )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,10 @@ set_target_properties( SFCGAL PROPERTIES VERSION ${SFCGAL_VERSION}
 
 target_link_libraries( SFCGAL CGAL::CGAL CGAL::CGAL_Core)
 
+if( "${CGAL_VERSION}" VERSION_GREATER_EQUAL "5.0.0")
+target_link_libraries( SFCGAL gmpxx )
+endif()
+
 target_link_libraries( SFCGAL ${Boost_LIBRARIES} )
 
 if ( ${Use_precompiled_headers} )

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -21,7 +21,6 @@
 #define _SFCGAL_CONFIG_H_
 
 #define CGAL_DO_NOT_USE_BOOST_MP 1
-#define CGAL_DO_NOT_USE_GMPXX 1
 
 #include <SFCGAL/export.h>
 


### PR DESCRIPTION
I added a condition to link sfcgal with gmpxx since it is necessary when cgal version >= 5.

I tested locally with postgis. As gmpxx is in sfcgal, there is no need to add gmpxx in sfcgal_config.in

Tests: 
- Ubuntu and CGAL 5.0 (CI Travis)
- FreeBSD, CGAL 4.13 (local and CI Cirrus)
- FreeBSD, CGAL 5.0.2 (local)

Fix #198 