### PR TITLE
Issue 200 fix intersection

### DIFF
--- a/CGAL_patches/CGAL/corefinement_operations.h
+++ b/CGAL_patches/CGAL/corefinement_operations.h
@@ -343,10 +343,15 @@ public:
     
     if (!intersection.empty())
     {
-      Volume_import_modifier modifier(final_map,intersection.begin(),intersection.end());
-      Output_polyhedron* new_poly=new Output_polyhedron();
-      new_poly->delegate(modifier);
-      *poly_output++=std::make_pair( new_poly,static_cast<int>(Intersection_tag) );
+        for (const auto& dart : intersection)
+        {
+            Volume_import_modifier modifier(final_map, dart);
+            Output_polyhedron *new_poly = new Output_polyhedron();
+            new_poly->delegate(modifier);
+            *poly_output++ = std::make_pair( new_poly
+                                           , static_cast<int>(Intersection_tag)
+                                           );
+        }
     }
     
     if (!P_minus_Q.empty())

--- a/src/algorithm/Intersection3D.cpp
+++ b/src/algorithm/Intersection3D.cpp
@@ -319,9 +319,12 @@ void _intersection_solid_solid( const MarkedPolyhedron& pa, const MarkedPolyhedr
         }
 
         // else, we have an intersection
-        MarkedPolyhedron* res_poly = result[0].first;
-        output.addPrimitive( *res_poly );
-        delete res_poly;
+        for (std::pair< MarkedPolyhedron*, int >& p : result )
+        {
+	    std::unique_ptr< MarkedPolyhedron > res_poly( p.first );
+	    output.addPrimitive( *res_poly );
+	    p.first = nullptr;
+        }
     }
 }
 

--- a/test/bench/BenchWKT.cpp
+++ b/test/bench/BenchWKT.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE( testReadTriangle )
     bench().start( boost::format( "READ WKT TRIANGLE" ) ) ;
 
     for ( int i = 0; i < N; i++ ) {
-        io::readWkt( "TRIANGLE((0 0,0 1000,1000 1000,1000 0,0 0))" ) ;
+        io::readWkt( "TRIANGLE((0 0,0 1000,1000 1000,0 0))" ) ;
     }
 
     bench().stop();

--- a/test/regress/standalone/SFCGAL/IntersectionTest.cpp
+++ b/test/regress/standalone/SFCGAL/IntersectionTest.cpp
@@ -20,6 +20,9 @@
 #include <SFCGAL/io/wkt.h>
 #include <SFCGAL/algorithm/intersection.h>
 #include <SFCGAL/Geometry.h>
+#include <SFCGAL/algorithm/extrude.h>
+#include <SFCGAL/algorithm/isValid.h>
+#include <SFCGAL/MultiSolid.h>
 
 #include "../../../test_config.h"
 
@@ -57,8 +60,47 @@ BOOST_AUTO_TEST_CASE( test_postgis_4157 )
     algorithm::intersection3D( *g1, *g2 );
 }
 
+BOOST_AUTO_TEST_CASE( test_sfcgal_issue_200 )
+{
+  std::unique_ptr< SFCGAL::Geometry > poly1 = SFCGAL::io::readWkt( "POLYGON(( 0 0"
+								           ", 1 0"
+								           ", 1 1"
+								           ", 0 1"
+								           ", 0 0"
+								           "))"
+								 );
+
+  std::unique_ptr< SFCGAL::Geometry > solid1 = SFCGAL::algorithm::extrude( *poly1
+									 , 0.0
+									 , 0.0
+									 , 1.0
+									 );
+
+  std::unique_ptr< SFCGAL::Geometry > poly2 = SFCGAL::io::readWkt( "POLYGON(( -1 0.2"
+								           ", 1.8 0.2"
+								           ", 1.8 0.4"
+								           ", -0.8 0.4"
+								           ", -0.8 0.6"
+								           ", 1.8 0.6"
+								           ", 1.8 0.8"
+								           ", -1 0.8"
+								           ", -1 0.2"
+								           "))"
+								 );
+
+  std::unique_ptr< SFCGAL::Geometry > solid2 = SFCGAL::algorithm::extrude( *poly2
+									 , 0.0
+									 , 0.0
+									 , 1.0
+									 );
+
+  std::unique_ptr< SFCGAL::Geometry > inx = SFCGAL::algorithm::intersection3D( *solid1
+									     , *solid2
+									     );
+
+  BOOST_CHECK( algorithm::isValid( *inx ) );
+  BOOST_CHECK_EQUAL( inx->geometryTypeId(), TYPE_MULTISOLID );
+  BOOST_CHECK_EQUAL( inx->as<MultiSolid>().numGeometries(), 2 );
+}
+
 BOOST_AUTO_TEST_SUITE_END()
-
-
-
-

--- a/test/unit/SFCGAL/algorithm/IntersectionTest.cpp
+++ b/test/unit/SFCGAL/algorithm/IntersectionTest.cpp
@@ -65,20 +65,6 @@ void insertOrReplace( boost::ptr_map<std::string, Geometry >& map, std::string k
     map.insert( key, value );
 }
 BOOST_AUTO_TEST_SUITE( SFCGAL_algorithm_IntersectionTest )
-                          
-BOOST_AUTO_TEST_CASE( testIssue200 )
-{
-  std::unique_ptr< SFCGAL::Geometry > poly1 = SFCGAL::io::readWkt( "POLYGON((0 0,1 0,1 1,0 1,0 0))" );
-  std::unique_ptr< SFCGAL::Geometry > solid1 = SFCGAL::algorithm::extrude( *poly1, 0.0, 0.0, 1.0 );
-
-  std::unique_ptr< SFCGAL::Geometry > poly2
-    = SFCGAL::io::readWkt( "POLYGON((-1 0.2,1.8 0.2,1.8 0.4,-0.8 0.4,-0.8 0.6,1.8 0.6,1.8 0.8,-1 0.8,-1 0.2))" );
-  std::unique_ptr< SFCGAL::Geometry > solid2 = SFCGAL::algorithm::extrude( *poly2, 0.0, 0.0, 1.0 );
-
-  std::unique_ptr< SFCGAL::Geometry > inx = SFCGAL::algorithm::intersection3D( *solid1, *solid2 );
-
-  BOOST_CHECK( SFCGAL::algorithm::isValid( *inx ) );
-}
 
 BOOST_AUTO_TEST_CASE( testFileIntersectionTest )
 {

--- a/test/unit/SFCGAL/algorithm/IntersectionTest.cpp
+++ b/test/unit/SFCGAL/algorithm/IntersectionTest.cpp
@@ -37,6 +37,8 @@
 #include <SFCGAL/MultiPolygon.h>
 #include <SFCGAL/MultiSolid.h>
 #include <SFCGAL/detail/transform/AffineTransform3.h>
+#include <SFCGAL/algorithm/extrude.h>
+#include <SFCGAL/algorithm/isValid.h>
 
 #include "../../../test_config.h"
 
@@ -63,6 +65,20 @@ void insertOrReplace( boost::ptr_map<std::string, Geometry >& map, std::string k
     map.insert( key, value );
 }
 BOOST_AUTO_TEST_SUITE( SFCGAL_algorithm_IntersectionTest )
+                          
+BOOST_AUTO_TEST_CASE( testIssue200 )
+{
+  std::unique_ptr< SFCGAL::Geometry > poly1 = SFCGAL::io::readWkt( "POLYGON((0 0,1 0,1 1,0 1,0 0))" );
+  std::unique_ptr< SFCGAL::Geometry > solid1 = SFCGAL::algorithm::extrude( *poly1, 0.0, 0.0, 1.0 );
+
+  std::unique_ptr< SFCGAL::Geometry > poly2
+    = SFCGAL::io::readWkt( "POLYGON((-1 0.2,1.8 0.2,1.8 0.4,-0.8 0.4,-0.8 0.6,1.8 0.6,1.8 0.8,-1 0.8,-1 0.2))" );
+  std::unique_ptr< SFCGAL::Geometry > solid2 = SFCGAL::algorithm::extrude( *poly2, 0.0, 0.0, 1.0 );
+
+  std::unique_ptr< SFCGAL::Geometry > inx = SFCGAL::algorithm::intersection3D( *solid1, *solid2 );
+
+  BOOST_CHECK( SFCGAL::algorithm::isValid( *inx ) );
+}
 
 BOOST_AUTO_TEST_CASE( testFileIntersectionTest )
 {


### PR DESCRIPTION
Fix for failing intersection issue #200 which generates an invalid Solid containing two disjoint parts when it should yield a single two part MultiSoild.

In summary, when recovering the vertices pertaining to each Polyhedra component of the desired intersection volume, we now process each 3-cell deemed relevant to the intersection result individually rather than collectively, since they may pertain to disjoint volumes. These volumes are now combined downstream  as separate primitives, preserving the disjoint nature of the components of the result if they are indeed disjoint.

Also added a standalone test to demonstrate the fix.