### PR TITLE
Issue #138: Corrected error message and updated documentation for straightskeleton regarding throwing notimplemented exception for polygon with touching rings.

### DIFF
--- a/src/algorithm/straightSkeleton.cpp
+++ b/src/algorithm/straightSkeleton.cpp
@@ -214,7 +214,7 @@ checkNoTouchingHoles( const Polygon& g )
             //       still dangerous. @todo find out !
             if ( ! inter->isEmpty() && inter->is< Point >() ) {
                 BOOST_THROW_EXCEPTION( NotImplementedException(
-                                           "straight skeleton of Polygon with touching interior rings is not implemented"
+                                           "straight skeleton of Polygon with point touching rings is not implemented."
                                        ) );
             }
         }

--- a/src/algorithm/straightSkeleton.h
+++ b/src/algorithm/straightSkeleton.h
@@ -41,6 +41,7 @@ struct NoValidityCheck;
  * @param g input geometry
  * @ingroup public_api
  * @pre g is a valid geometry
+ * @throws NotImplementedException If g is a Polygon with point touching rings.
  */
 SFCGAL_API std::unique_ptr< MultiLineString > approximateMedialAxis( const Geometry& g );
 
@@ -52,6 +53,7 @@ SFCGAL_API std::unique_ptr< MultiLineString > approximateMedialAxis( const Geome
  * @param outputM whether to output the distance to border as M
  * @ingroup public_api
  * @pre g is a valid geometry
+ * @throws NotImplementedException If g is a Polygon with point touching rings.
  */
 SFCGAL_API std::unique_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation = true, bool innerOnly = false, bool outputDistanceInM = false ) ;
 
@@ -63,17 +65,21 @@ SFCGAL_API std::unique_ptr< MultiLineString > straightSkeleton( const Geometry& 
  * @ingroup public_api
  * @pre g is a valid geometry
  * @warning No actual validity check is done
+ * @throws NotImplementedException If g is a Polygon with point touching rings.
  */
 SFCGAL_API std::unique_ptr< MultiLineString > straightSkeleton( const Geometry& g, bool autoOrientation, NoValidityCheck, bool innerOnly = false, bool outputDistanceInM = false ) ;
 
 /**
  * @brief build a 2D straight skeleton for a Polygon
  * @ingroup detail
+ * @throws NotImplementedException If g is a Polygon with point touching rings.
  */
 SFCGAL_API std::unique_ptr< MultiLineString > straightSkeleton( const Polygon& g, bool autoOrientation = true, bool innerOnly = false, bool outputDistanceInM = false ) ;
+
 /**
  * @brief build a 2D straight skeleton for a Polygon
  * @ingroup detail
+ * @throws NotImplementedException If g is a Polygon with point touching rings.
  */
 SFCGAL_API std::unique_ptr< MultiLineString > straightSkeleton( const MultiPolygon& g, bool autoOrientation = true, bool innerOnly = false, bool outputDistanceInM = false ) ;
 


### PR DESCRIPTION
* Corrected error message and updated documentation for straightskeleton regarding throwing notimplemented exception for polygon with touching rings, which was misleading for client raising the issue.